### PR TITLE
Fix README config file name inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ And at the end of `fluent-bit.conf`, add the following to set up input and outpu
     maxRecords 1024
 ```
 
-* Restart Fluent Bit: `fluent-bit -c /path/to/fluent.conf`
+* Restart Fluent Bit: `fluent-bit -c /path/to/fluent-bit.conf`
 * Append a test log message to your log file: `echo "test message" >> /path/to/your/log/file`
 * Search New Relic Logs for `"test message"`
 


### PR DESCRIPTION
We used `fluent-bit.conf` in 4 places, in a `fluent.conf` in one. 

I was also going to note (hat tip: Ian) that the config file can have any name, but we ship with `fluent-bit.conf`, so thought not saying anything was the least confusing option. 🤷‍♂️