### PR TITLE
Make azure pipeline build x86 and amd64 windows dlls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 all:
 	go build -buildmode=c-shared -o out_newrelic.so .
-	go build -buildmode=c-shared -o out_newrelic.dll .
+
+win64:
+	go build -buildmode=c-shared -o out_newrelic_win64.dll .
+
+win32:
+	go build -buildmode=c-shared -o out_newrelic_win32.dll .
 
 fast:
 	go build out_newrelic.go

--- a/merge-to-master-pipeline.yml
+++ b/merge-to-master-pipeline.yml
@@ -40,15 +40,33 @@ steps:
     testResultsFiles: '$(modulePath)/test-results.xml'
     failTaskOnFailedTests: true
 
+- script: sudo apt install mingw-w64
+  displayName: 'Get mingw'
+
 - task: Bash@3
-  displayName: 'Build the plugin'
   inputs:
     targetType: 'inline'
     workingDirectory: '$(modulePath)'
     script: |
       VERSION=`cat version.go | grep VERSION | awk '{gsub(/"/, "", $4); print $4}'`
       echo "##vso[task.setvariable variable=VERSION]$VERSION"
-      make all
+  displayName: 'Get the current version into a variable'
+
+- script: make all
+  workingDirectory: '$(modulePath)'
+  displayName: 'Build .so file'
+
+- script: |
+    env CGO_ENABLED=1 GOOS=windows GOARCH=386 CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ 
+    make win32
+  workingDirectory: '$(modulePath)'
+  displayName: 'Build Windows 32-bit DLL'
+
+- script: |
+    env CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++
+    make win64
+  workingDirectory: '$(modulePath)'
+  displayName: 'Build Windows 64-bit DLL'
 
 - task: Docker@2
   displayName: Login to Docker Hub
@@ -74,6 +92,7 @@ steps:
     tag: '$(VERSION)'
     assets: |
       $(modulePath)/out_newrelic.so
-      $(modulePath)/out_newrelic.dll
+      $(modulePath)/out_newrelic_win32.dll
+      $(modulePath)/out_newrelic_win64.dll
     changeLogCompareToRelease: 'lastFullRelease'
     changeLogType: 'commitBased'

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.1.4"
+const VERSION = "1.1.5"


### PR DESCRIPTION
This PR makes azure build pipelines use the correct compilers for windows and compiles each DLL and .so file separately and uploads it to a github release