### PR TITLE
Bump version to 1.1.6

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.1.5"
+const VERSION = "1.1.6"


### PR DESCRIPTION
We had a docs-only PR before this that didn't bump the version,
and the merge-to-master build failed, and the latest release
doesn't have that docs change.