### PR TITLE
LOGGING-2378: Fixes HTTPS proxy support and improves documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ If you want to bypass the system-wide defined proxy for some reason, you can use
 
 You can also specify a custom proxy to send the logs to (different from the system-wide defined) by using the `proxy` configuration parameter.
 
+HTTPS proxies (having an `https://...` URL) use a certificate to encrypt the connection between the plugin and the proxy. If you are using a self-signed certificate (not trusted by the Certification Authorities defined at your system level), you can:
+* Windows: import the self-signed certificate (PEM file) using the MMC tool. You can refer to [this link](https://www.ssls.com/knowledgebase/how-to-import-intermediate-and-root-certificates-via-mmc/), but in Step 2 ensure to import it in your "Trusted Root Certification Authorities" instead of importing it in the "Intermediate Certification Authorities".
+* Linux: you can specify the self-signed certificate (PEM file) using either the `caBundleFile` or `caBundleDir` parameters (see next section).
+
+Optionally, you can skip the self-signed certificate verification by setting `validateProxyCerts` to `false`, but please note that this option is not considered safe due to potential Man In The Middle Attacks.
+
+A example setup, which defines an HTTPS proxy and its self-signed certificate, would result in the following configuration:
+
+```
+[OUTPUT]
+    Name newrelic
+    Match *
+    licenseKey <NEW_RELIC_LICENSE_KEY>
+    proxy: https://https-proxy-hostname:3129
+    # REMOVE following option when using it on Windows (see above)
+    caBundleFile: /path/to/proxy-certificate-bundle.pem
+```
+
 ## Configuration Parameters
 
 The plugin supports the following configuration parameters and include either an Insights or License Key:
@@ -101,9 +119,9 @@ The plugin supports the following configuration parameters and include either an
 |maxRecords          |  The maximum number of records to send at a time  | 1024 |   
 |proxy               |  Optional proxy to communicate with New Relic, overrides any environment-defined one. Must follow the format `https://user:password@hostname:port`. Can be HTTP or HTTPS. | (none) |
 |ignoreSystemProxy   |  Ignore any proxy defined via the `HTTP_PROXY` or `HTTPS_PROXY` environment variables. Note that if a proxy has been defined using the `proxy` parameter, this one has no effect. | false |
-|caBundleFile        |  Specifies the Certificate Authority certificate to use for validating HTTPS connections against the proxy. Useful when the proxy uses a self-signed certificate. **The certificate file must be in the PEM format**. If not specified, then the operating system's CA list is used. Only used when `validateProxyCerts` is `true`. | (none) |
-|caBundleDir         |  Specifies a folder containing one or more Certificate Authority certificates ot use for validating HTTPS connections against the proxy. Useful when the proxy uses a self-signed certificate. **Only certificate files in the PEM format and \*.pem extension will be considered**. If not specified, then the operating system's CA list is used. Only used when `validateProxyCerts` is `true`.  | (none) |
-|validateProxyCerts  |  When using a HTTPS proxy, the proxy certificates are validated by default when establishing a HTTPS connection. To disable the proxy certificate validation, set `validateProxyCerts` to `false` (insecure) | true |
+|caBundleFile        |  **[LINUX HTTPS ONLY]** Specifies the Certificate Authority certificate to use for validating HTTPS connections against the proxy. Useful when the proxy uses a self-signed certificate. **The certificate file must be in the PEM format**. If not specified, then the operating system's CA list is used. Only used when `validateProxyCerts` is `true`. | (none) |
+|caBundleDir         |  **[LINUX HTTPS ONLY]** Specifies a folder containing one or more Certificate Authority certificates ot use for validating HTTPS connections against the proxy. Useful when the proxy uses a self-signed certificate. **Only certificate files in the PEM format and \*.pem extension will be considered**. If not specified, then the operating system's CA list is used. Only used when `validateProxyCerts` is `true`.  | (none) |
+|validateProxyCerts  |  **[HTTPS ONLY]** When using a HTTPS proxy, the proxy certificates are validated by default when establishing a HTTPS connection. To disable the proxy certificate validation, set `validateProxyCerts` to `false` (insecure) | true |
 
 For information on how to find your New Relic Insights Insert key, take a look at the 
 documentation [here](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register).

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.2.0"
+const VERSION = "1.2.1"


### PR DESCRIPTION
# Description

There are 2 kinds of proxies that are able to forward HTTPS traffic:

1. "Plain HTTPS proxies", which can potentially inspect the traffic sent by its clients. The clients need to accept its certificate, and need to first send a FORWARD (CONNECT) request to establish the connection, prior to the TLS handshake.
2. "TCP proxies", which don't require HTTPS specifically to work and therefore should handle the TLS handshake without any prior HTTP CONNECT initiator.

Go 1.10 introduced a breaking change with regards to this: proxied HTTPS connections are established using a single plain TCP based TLS handshake (with no prior HTTP CONNECT initiator), which only works in "TCP Proxies" (like Squid). Therefore, "Plain HTTPS proxies" (like Charles) cannot work in this setup.

The `infra-agent` team has provided a fix for this. This PR basically ports these changes to the output plugin. The new implementation tries plain TCP based TLS handshake first, as it did for previous releases. And if this fails it falls back to usual HTTPS proxy setup dialing, triggering an initial HTTP CONNECT before proxy TLS handshake is initiated.

# Tests performed
Manually sent messages using a standalone Fluentbit installation, both via a Squid and a Charles proxy. Results:

Charles: OK
```
2020/05/06 11:17:35 [DEBUG] dialing to proxy via TLS
2020/05/06 11:17:35 [DEBUG] TLS handshake cannot be established. Retrying with HTTP CONNECT
```

Squid: OK
```
2020/05/06 11:21:06 [DEBUG] dialing to proxy via TLS
2020/05/06 11:21:06 [DEBUG] usual, secured configuration worked as expected. Defaulting to it
```

Logs were received using both proxies: OK