### PR TITLE
LOGGING-2555: Adds support for JSON arrays within a log record

### DIFF
--- a/record/record_test.go
+++ b/record/record_test.go
@@ -63,15 +63,58 @@ var _ = Describe("Out New Relic", func() {
 		})
 
 		It("Correctly massage nested map[interface]interface{} to map[string]interface{}", func() {
-			inputMap := make(FluentBitRecord)
-			nestedMap := make(map[interface{}]interface{})
-			expectedOutput := make(LogRecord)
-			expectedNestedOutput := make(LogRecord)
-			expectedNestedOutput["foo"] = "bar"
-			expectedOutput["nested"] = expectedNestedOutput
-			nestedMap["foo"] = "bar"
-			inputMap["nested"] = nestedMap
+			// Given
+			inputMap := map[interface{}]interface{}{
+				"nestedMap": map[interface{}]interface{}{
+					"foo":     "bar",
+					"numeric": 2,
+				},
+			}
+
+			// When
 			foundOutput := parseRecord(inputMap)
+
+			// Then
+			expectedOutput := map[string]interface{}{
+				"nestedMap": map[string]interface{}{
+					"foo":     "bar",
+					"numeric": 2,
+				},
+			}
+			Expect(foundOutput).To(Equal(expectedOutput))
+		})
+
+		It("Correctly handles a JSON array in a []interface{}", func() {
+			// Given
+			inputRecord := map[interface{}]interface{}{
+				"nestedArray": []interface{}{
+					map[interface{}]interface{}{
+						"stringField":  "value1",
+						"numericField": 1,
+					},
+					map[interface{}]interface{}{
+						"stringField":  "value2",
+						"numericField": 2,
+					},
+				},
+			}
+
+			// When
+			foundOutput := parseRecord(inputRecord)
+
+			// Then
+			expectedOutput := map[string]interface{}{
+				"nestedArray": []interface{}{
+					map[string]interface{}{
+						"stringField":  "value1",
+						"numericField": 1,
+					},
+					map[string]interface{}{
+						"stringField":  "value2",
+						"numericField": 2,
+					},
+				},
+			}
 			Expect(foundOutput).To(Equal(expectedOutput))
 		})
 	})

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.4.0"
+const VERSION = "1.4.1"


### PR DESCRIPTION
# Description
The current implementation of the plugin doesn't support parsing a JSON having an array of JSON objects inside of it. The field ends up becoming a []interface{}, which then contains a list of map[interface{}]interface{}. This scenario is not currently handled (it’s missing a clause for []interface{} here), and then the resulting object contains a `map[interface{}]interface{}` which cannot be converted back to JSON.

# Tests
The introduced change includes a unit test precisely testing the buggy scenario