### PR TITLE
Update out_newrelic.go

### DIFF
--- a/merge-to-master-pipeline.yml
+++ b/merge-to-master-pipeline.yml
@@ -19,6 +19,7 @@ steps:
     mkdir -p '$(GOBIN)'
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'
+    ls /usr/local
     shopt -s extglob
     mv !(gopath) '$(modulePath)'
     echo '##vso[task.prependpath]$(GOBIN)'

--- a/merge-to-master-pipeline.yml
+++ b/merge-to-master-pipeline.yml
@@ -10,13 +10,13 @@ pool:
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  GOROOT: '/usr/local/go1.12.17'
+  # GOROOT: '/usr/local/go1.12.17'
   GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
   modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
 
 steps:
 - script: |
-    ls -l /usr/local
+    find . -name go -print
     mkdir -p '$(GOBIN)'
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'

--- a/merge-to-master-pipeline.yml
+++ b/merge-to-master-pipeline.yml
@@ -16,7 +16,6 @@ variables:
 
 steps:
 - script: |
-    find . -name go -print
     mkdir -p '$(GOBIN)'
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'

--- a/merge-to-master-pipeline.yml
+++ b/merge-to-master-pipeline.yml
@@ -10,7 +10,6 @@ pool:
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  # GOROOT: '/usr/local/go1.12.17'
   GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
   modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
 

--- a/merge-to-master-pipeline.yml
+++ b/merge-to-master-pipeline.yml
@@ -16,10 +16,10 @@ variables:
 
 steps:
 - script: |
+    ls -l /usr/local
     mkdir -p '$(GOBIN)'
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'
-    ls /usr/local
     shopt -s extglob
     mv !(gopath) '$(modulePath)'
     echo '##vso[task.prependpath]$(GOBIN)'

--- a/out_newrelic.go
+++ b/out_newrelic.go
@@ -64,7 +64,7 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 	// output.FLB_ERROR = unrecoverable error, do not try this again.
 	// output.FLB_RETRY = retry to flush later.
 	if err := nrClient.Send(buffer); err != nil {
-		return output.FLB_ERROR
+		return output.FLB_RETRY
 	} else {
 		return output.FLB_OK
 	}

--- a/pr-pipeline.yml
+++ b/pr-pipeline.yml
@@ -8,13 +8,13 @@ pool:
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  GOROOT: '/usr/local/go1.12.17'
+  # GOROOT: '/usr/local/go1.12.17'
   GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
   modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
 
 steps:
 - script: |
-    ls /usr/local
+    find . -name go -print
     mkdir -p '$(GOBIN)'
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'

--- a/pr-pipeline.yml
+++ b/pr-pipeline.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-    - '*' 
+    - '*'
 
 pool:
   vmImage: 'ubuntu-16.04' # Has Docker
@@ -14,6 +14,7 @@ variables:
 
 steps:
 - script: |
+    ls /usr/local
     mkdir -p '$(GOBIN)'
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'

--- a/pr-pipeline.yml
+++ b/pr-pipeline.yml
@@ -8,7 +8,6 @@ pool:
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  # GOROOT: '/usr/local/go1.12.17'
   GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
   modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
 

--- a/pr-pipeline.yml
+++ b/pr-pipeline.yml
@@ -14,7 +14,6 @@ variables:
 
 steps:
 - script: |
-    find . -name go -print
     mkdir -p '$(GOBIN)'
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'


### PR DESCRIPTION
As currently implemented, when NR ingest endpoint is unreachable, the plugin drops log entries.  This update enables the default in-memory buffering to work.  Optionally, file storage buffering can be used too.  

Note that retries are driven by the FB scheduler, which uses exponential backoff with jitter, this means that delayed logs can sit for minutes to hours before delivery.