### PR TITLE
Upgrade Fluent Bit to resolve CVE-2020-35963

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV SOURCE docker
 RUN go get github.com/fluent/fluent-bit-go/output
 RUN make linux-amd64
 
-FROM fluent/fluent-bit:1.7.4
+FROM fluent/fluent-bit:1.7.9
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-amd64-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV SOURCE docker
 RUN go get github.com/fluent/fluent-bit-go/output
 RUN make linux-amd64
 
-FROM fluent/fluent-bit:1.6.2
+FROM fluent/fluent-bit:1.7.4
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-amd64-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.4.7"
+const VERSION = "1.5.1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.4.6"
+const VERSION = "1.4.7"


### PR DESCRIPTION
CVE reference: https://nvd.nist.gov/vuln/detail/CVE-2020-35963

This pull request bumps the bundled version of Fluent Bit to the newest release. I chose the newest release (instead of the bare minimum, 1.6.4) since the Fluent Bit release notes did not call out any specific gotchas when upgrading from 1.6.x, so it should be pretty plug-and-play.

Oh, and hi @bmcfeely! 👋  TW sends its regards 😁  