### PR TITLE
[LOGGING-4394] Testing Firelens automatic publishing

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -79,7 +79,36 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Image digest
-        run: 'echo "Published image with digest: ${{ steps.docker_build.outputs.digest }}"'
+          run: 'echo "Published Docker image with digest: ${{ steps.docker_build.outputs.digest }}"'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build and Publish Docker image for Firelens
+        uses: docker/build-push-action@v2
+        env:
+          ECR_REGISTRY: 533243300146.dkr.ecr.us-east-2.amazonaws.com
+          ECR_REPOSITORY: newrelic/logging-firelens-fluentbit
+          IMAGE_TAG: ${{ env.VERSION }}
+        with:
+          context: ./
+          file: ./Dockerfile_firelens
+          push: true
+          tags: '${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}'
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Image digest
+        run: 'echo "Published Docker Firelens image with digest: ${{ steps.docker_build.outputs.digest }}"'
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -79,7 +79,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Image digest
-          run: 'echo "Published Docker image with digest: ${{ steps.docker_build.outputs.digest }}"'
+        run: 'echo "Published Docker image with digest: ${{ steps.docker_build.outputs.digest }}"'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Build and Publish Docker image for Firelens
         uses: docker/build-push-action@v2
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: 533243300146.dkr.ecr.us-east-2.amazonaws.com
           ECR_REPOSITORY: newrelic/logging-firelens-fluentbit
           IMAGE_TAG: ${{ env.VERSION }}
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,13 +56,13 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
-    - name: Build Docker image for Firelens
-      uses: docker/build-push-action@v2
-      with:
-        context: ./
-        file: ./Dockerfile_firelens
-        push: false
-        tags: 'pr-tag'
-        builder: ${{ steps.buildx.outputs.name }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Build Docker image for Firelens
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile_firelens
+          push: false
+          tags: 'pr-tag'
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,20 +17,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Run unit tests
-        run: |
-          go get -v -u github.com/jstemmer/go-junit-report
-          go test  -v ./... 2>&1 | go-junit-report > test-results.xml
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.5
-        if: always()
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: test-results.xml
-
-      - name: Build project
-        run: make linux-amd64
+#      - name: Run unit tests
+#        run: |
+#          go get -v -u github.com/jstemmer/go-junit-report
+#          go test  -v ./... 2>&1 | go-junit-report > test-results.xml
+#
+#      - name: Publish Unit Test Results
+#        uses: EnricoMi/publish-unit-test-result-action@v1.5
+#        if: always()
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: test-results.xml
+#
+#      - name: Build project
+#        run: make linux-amd64
 
       # The Docker Buildx builder will be used later to leverage from the cache while building the image
       - name: Set up Docker Buildx
@@ -45,13 +45,39 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: ${{ runner.os }}-buildx-
 
-      - name: Build Docker image
+#      - name: Build Docker image
+#        uses: docker/build-push-action@v2
+#        with:
+#          context: ./
+#          file: ./Dockerfile
+#          push: false
+#          tags: 'pr-tag'
+#          builder: ${{ steps.buildx.outputs.name }}
+#          cache-from: type=local,src=/tmp/.buildx-cache
+#          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build and Publish Docker image for Firelens
         uses: docker/build-push-action@v2
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: newrelic/logging-firelens-fluentbit
+          IMAGE_TAG: ${{ env.VERSION }}
         with:
           context: ./
-          file: ./Dockerfile
-          push: false
-          tags: 'pr-tag'
+          file: ./Dockerfile_firelens
+          push: true
+          tags: '${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}'
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,7 +72,7 @@ jobs:
         env:
           ECR_REGISTRY: 533243300146.dkr.ecr.us-east-2.amazonaws.com
           ECR_REPOSITORY: newrelic/logging-firelens-fluentbit
-          IMAGE_TAG: ${{ env.VERSION }}
+          IMAGE_TAG: test
         with:
           context: ./
           file: ./Dockerfile_firelens

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,20 +17,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-#      - name: Run unit tests
-#        run: |
-#          go get -v -u github.com/jstemmer/go-junit-report
-#          go test  -v ./... 2>&1 | go-junit-report > test-results.xml
-#
-#      - name: Publish Unit Test Results
-#        uses: EnricoMi/publish-unit-test-result-action@v1.5
-#        if: always()
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: test-results.xml
-#
-#      - name: Build project
-#        run: make linux-amd64
+      - name: Run unit tests
+        run: |
+          go get -v -u github.com/jstemmer/go-junit-report
+          go test  -v ./... 2>&1 | go-junit-report > test-results.xml
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.5
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: test-results.xml
+
+      - name: Build project
+        run: make linux-amd64
 
       # The Docker Buildx builder will be used later to leverage from the cache while building the image
       - name: Set up Docker Buildx
@@ -45,39 +45,24 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: ${{ runner.os }}-buildx-
 
-#      - name: Build Docker image
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: ./
-#          file: ./Dockerfile
-#          push: false
-#          tags: 'pr-tag'
-#          builder: ${{ steps.buildx.outputs.name }}
-#          cache-from: type=local,src=/tmp/.buildx-cache
-#          cache-to: type=local,dest=/tmp/.buildx-cache
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Build and Publish Docker image for Firelens
+      - name: Build Docker image
         uses: docker/build-push-action@v2
-        env:
-          ECR_REGISTRY: 533243300146.dkr.ecr.us-east-2.amazonaws.com
-          ECR_REPOSITORY: newrelic/logging-firelens-fluentbit
-          IMAGE_TAG: test
         with:
           context: ./
-          file: ./Dockerfile_firelens
-          push: true
-          tags: '${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}'
+          file: ./Dockerfile
+          push: false
+          tags: 'pr-tag'
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+
+    - name: Build Docker image for Firelens
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./Dockerfile_firelens
+        push: false
+        tags: 'pr-tag'
+        builder: ${{ steps.buildx.outputs.name }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,0 +1,20 @@
+FROM golang:1.11 AS builder
+
+WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
+
+COPY Makefile go.* *.go /go/src/github.com/newrelic/newrelic-fluent-bit-output/
+COPY config/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/config
+COPY nrclient/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/nrclient
+COPY record/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/record
+COPY utils/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/utils
+
+ENV SOURCE docker
+RUN go get github.com/fluent/fluent-bit-go/output
+RUN make linux-amd64
+
+FROM amazon/aws-for-fluent-bit:2.14.0
+
+COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-amd64-*.so /fluent-bit/bin/out_newrelic.so
+COPY *.conf /fluent-bit/etc/
+
+CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf", "-e", "/fluent-bit/bin/out_newrelic.so"]

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.4.6"
+const VERSION = "1.5.0"


### PR DESCRIPTION
# Description
This PR adds the automatic building of Firelens AWS images (see docs [here](https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/aws-firelens-plugin-log-forwarding/)), both as part of the PR and when merging to the main branch. When merging to the main branch, it also publishes automatically to the related Newrelic's AWS ECR repository.