### PR TITLE
[LOGGING-5152] Update fluent bit to 1.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV SOURCE docker
 RUN go get github.com/fluent/fluent-bit-go/output
 RUN make linux-amd64
 
-FROM fluent/fluent-bit:1.7.9
+FROM fluent/fluent-bit:1.8.1
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-amd64-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -12,7 +12,7 @@ ENV SOURCE docker
 RUN go get github.com/fluent/fluent-bit-go/output
 RUN make linux-amd64
 
-FROM fluent/fluent-bit:1.7.9-debug
+FROM fluent/fluent-bit:1.8.1-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-amd64-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -12,7 +12,7 @@ ENV SOURCE docker
 RUN go get github.com/fluent/fluent-bit-go/output
 RUN make linux-amd64
 
-FROM amazon/aws-for-fluent-bit:2.14.0
+FROM amazon/aws-for-fluent-bit:2.17.0
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-amd64-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.6.0"
+const VERSION = "1.6.1"


### PR DESCRIPTION
This PR updates the fluent-bit version to 1.8.1 in all Dockerfiles

- Dockerfile
- Dockerfile_debug
- Dockerfile_firelens

In the firelens one we're using aws-for-fluent-bit 2.1.7, which includes fluent bit 1.8.1 (https://github.com/aws/aws-for-fluent-bit/releases/tag/2.17.0) 