### PR TITLE
[LOGGING-5125] Add docker image tests to the pipeline

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Run unit tests
         run: |
           go get -v -u github.com/jstemmer/go-junit-report
-          go test  -v ./... 2>&1 | go-junit-report > test-results.xml
+          go test -v ./... 2>&1 | go-junit-report > test-results.xml
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.5
@@ -59,8 +59,6 @@ jobs:
 
       - name: Test Docker image
         run: bash test.sh
-        env:
-          SKIP_BUILD: "yes"
 
       - name: Build Docker debug image
         uses: docker/build-push-action@v2
@@ -76,8 +74,6 @@ jobs:
 
       - name: Test Docker debug image
         run: bash test.sh
-        env:
-          SKIP_BUILD: "yes"
 
       - name: Build Docker image for Firelens
         uses: docker/build-push-action@v2
@@ -93,5 +89,3 @@ jobs:
 
       - name: Test Docker firelens image
         run: bash test.sh
-        env:
-          SKIP_BUILD: "yes"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Test Docker image
         run: bash test.sh
         env:
-          SKIP_BUILD: "yes"
+          DOCKERFILE: "./Dockerfile"
 
       - name: Build Docker debug image
         uses: docker/build-push-action@v2
@@ -75,7 +75,7 @@ jobs:
       - name: Test Docker debug image
         run: bash test.sh
         env:
-          SKIP_BUILD: "yes"
+          DOCKERFILE: "./Dockerfile_debug"
 
       - name: Build Docker image for Firelens
         uses: docker/build-push-action@v2
@@ -91,4 +91,4 @@ jobs:
       - name: Test Docker firelens image
         run: bash test.sh
         env:
-          SKIP_BUILD: "yes"
+          DOCKERFILE: "./Dockerfile_firelens"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,10 +51,15 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: false
-          tags: 'pr-tag'
+          tags: fb-output-plugin
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Test Docker image
+        run: sh test.sh
+        env:
+          SKIP_BUILD: "yes"
 
       - name: Build Docker debug image
         uses: docker/build-push-action@v2
@@ -62,10 +67,15 @@ jobs:
           context: ./
           file: ./Dockerfile_debug
           push: false
-          tags: 'pr-tag'
+          tags: fb-output-plugin
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Test Docker debug image
+        run: sh test.sh
+        env:
+          SKIP_BUILD: "yes"
 
       - name: Build Docker image for Firelens
         uses: docker/build-push-action@v2
@@ -73,7 +83,12 @@ jobs:
           context: ./
           file: ./Dockerfile_firelens
           push: false
-          tags: 'pr-tag'
+          tags: fb-output-plugin
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Test Docker firelens image
+        run: sh test.sh
+        env:
+          SKIP_BUILD: "yes"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,7 +57,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Test Docker image
-        run: sh test.sh
+        run: bash test.sh
         env:
           SKIP_BUILD: "yes"
 
@@ -73,7 +73,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Test Docker debug image
-        run: sh test.sh
+        run: bash test.sh
         env:
           SKIP_BUILD: "yes"
 
@@ -89,6 +89,6 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Test Docker firelens image
-        run: sh test.sh
+        run: bash test.sh
         env:
           SKIP_BUILD: "yes"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,6 +51,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: false
+          load: true
           tags: fb-output-plugin
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -59,7 +60,7 @@ jobs:
       - name: Test Docker image
         run: bash test.sh
         env:
-          DOCKERFILE: "./Dockerfile"
+          SKIP_BUILD: "yes"
 
       - name: Build Docker debug image
         uses: docker/build-push-action@v2
@@ -67,6 +68,7 @@ jobs:
           context: ./
           file: ./Dockerfile_debug
           push: false
+          load: true
           tags: fb-output-plugin
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -75,7 +77,7 @@ jobs:
       - name: Test Docker debug image
         run: bash test.sh
         env:
-          DOCKERFILE: "./Dockerfile_debug"
+          SKIP_BUILD: "yes"
 
       - name: Build Docker image for Firelens
         uses: docker/build-push-action@v2
@@ -83,6 +85,7 @@ jobs:
           context: ./
           file: ./Dockerfile_firelens
           push: false
+          load: true
           tags: fb-output-plugin
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -91,4 +94,4 @@ jobs:
       - name: Test Docker firelens image
         run: bash test.sh
         env:
-          DOCKERFILE: "./Dockerfile_firelens"
+          SKIP_BUILD: "yes"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 out_newrelic*.h
 out_newrelic*.so
 out_newrelic*.dll
+test/testdata

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Testing steps are:
    - The built docker image with fluent bit configuration from ./test/fluent-bit.conf
 4. Send some logs
 5. Verify that logs are reaching the mockserver
+   - Mockserver requests are verified using ./test/verification.json
 6. Cleanup
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ The **newrelic-fluent-bit-output** plugin forwards output to New Relic.
 It works on all versions of Fluent Bit greater than 0.12 but for the best experience we recommend using versions greater than 1.0.
 
 ## Getting started
+
 In order to insert records into New Relic, you can configure the plugin with a config file or configure it via command line flags.
-* [Link to configuration](https://docs.fluentbit.io/manual/configuration)
+
+- [Link to configuration](https://docs.fluentbit.io/manual/configuration)
 
 You can download the output plugin pre-compiled under our [releases](https://github.com/newrelic/newrelic-fluent-bit-output/releases/latest).
-Alternatively you can compile the plugin yourself and store ```out_newrelic.so``` or ```out_newrelic_winXX.dll``` at a location that can be accessed by the fluent-bit daemon.
+Alternatively you can compile the plugin yourself and store `out_newrelic.so` or `out_newrelic_winXX.dll` at a location that can be accessed by the fluent-bit daemon.
 
 Note that for certain Linux Enterprise users,
 [including CentOS 7, Debian 8 and 9, Ubuntu, and Raspbian 8](https://fluentbit.io/documentation/0.13/installation/td-agent-bit.html),
@@ -23,10 +25,12 @@ just replace it with `td-agent-bit` (for example, you will need to edit `td-agen
 This project is provided AS-IS WITHOUT WARRANTY OR SUPPORT, although you can report issues and contribute to the project here on GitHub.
 
 Prerequisites:
-* Fluent Bit
-* a Go environment
+
+- Fluent Bit
+- a Go environment
 
 To build the plugin:
+
 1. Clone [https://github.com/newrelic/newrelic-fluent-bit-output](https://github.com/newrelic/newrelic-fluent-bit-output)
 2. Build plugin: `cd newrelic-fluent-bit-output && go get github.com/fluent/fluent-bit-go/output && make {OS}`
    1. `make all` for linux/unix
@@ -41,19 +45,23 @@ It is vitally important to pay attention to white space in your config files. Pl
 and one space between keys and values.
 
 ### plugins.conf
+
 Find or create a `plugins.conf` file in your Fluent Bit directory and add a reference to out_newrelic.so or out_newrelic_winXX.dll,
 adjacent to your `fluent-bit.conf` file.
 
 in plugins.conf
+
 ```
 [PLUGINS]
     Path /path/to/newrelic-fluent-bit-output/out_newrelic.so
 ```
 
 ### fluent-bit.conf
+
 Modify fluent-bit.conf and add the following line under the `[SERVICE]` block:
 
 in fluent-bit.conf
+
 ```
 [SERVICE]
     # This is the main configuration block for fluent bit.
@@ -62,6 +70,7 @@ in fluent-bit.conf
 ```
 
 And at the end of `fluent-bit.conf`, add the following to set up the input and output filter:
+
 ```
 [INPUT]
     Name tail
@@ -79,11 +88,12 @@ And at the end of `fluent-bit.conf`, add the following to set up the input and o
     Add service_name <SERVICE_NAME>
 ```
 
-* Restart Fluent Bit: `fluent-bit -c /path/to/fluent-bit.conf`
-* Append a test log message to your log file: `echo "test message" >> /path/to/your/log/file`
-* Search New Relic Logs for `"test message"`
+- Restart Fluent Bit: `fluent-bit -c /path/to/fluent-bit.conf`
+- Append a test log message to your log file: `echo "test message" >> /path/to/your/log/file`
+- Search New Relic Logs for `"test message"`
 
 ## Proxy support
+
 The plugin automatically detects the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, and automatically uses them to set up the proxy configuration.
 
 If you want to bypass the system-wide defined proxy for some reason, you can use the `ignoreSystemProxy` configuration parameter.
@@ -91,8 +101,9 @@ If you want to bypass the system-wide defined proxy for some reason, you can use
 You can also specify a custom proxy to send the logs to (different from the system-wide defined) by using the `proxy` configuration parameter.
 
 HTTPS proxies (having an `https://...` URL) use a certificate to encrypt the connection between the plugin and the proxy. If you are using a self-signed certificate (not trusted by the Certification Authorities defined at your system level), you can:
-* Windows: import the self-signed certificate (PEM file) using the MMC tool. You can refer to [this link](https://www.ssls.com/knowledgebase/how-to-import-intermediate-and-root-certificates-via-mmc/), but in Step 2 ensure to import it in your "Trusted Root Certification Authorities" instead of importing it in the "Intermediate Certification Authorities".
-* Linux: you can specify the self-signed certificate (PEM file) using either the `caBundleFile` or `caBundleDir` parameters (see next section).
+
+- Windows: import the self-signed certificate (PEM file) using the MMC tool. You can refer to [this link](https://www.ssls.com/knowledgebase/how-to-import-intermediate-and-root-certificates-via-mmc/), but in Step 2 ensure to import it in your "Trusted Root Certification Authorities" instead of importing it in the "Intermediate Certification Authorities".
+- Linux: you can specify the self-signed certificate (PEM file) using either the `caBundleFile` or `caBundleDir` parameters (see next section).
 
 Optionally, you can skip the self-signed certificate verification by setting `validateProxyCerts` to `false`, but please note that this option is not considered safe due to potential Man In The Middle Attacks.
 
@@ -112,18 +123,18 @@ A example setup, which defines an HTTPS proxy and its self-signed certificate, w
 
 The plugin supports the following configuration parameters and include either an Insights or License Key:
 
-| Key | Description | Default |
-|-----|-------------|---------|
-|endpoint            |  The endpoint you send data to |  `https://log-api.newrelic.com/log/v1` |
-|apiKey              |  Your New Relic Insights Insert key | (none)   |
-|licenseKey          |  Your New Relic License key         | (none)   |
-|maxBufferSize       |  **[Deprecated since 1.3.0]** The maximum size the payloads sent in bytes  | 256000 |
-|maxRecords          |  **[Deprecated since 1.3.0]** The maximum number of records to send at a time  | 1024 |
-|proxy               |  Optional proxy to communicate with New Relic, overrides any environment-defined one. Must follow the format `https://user:password@hostname:port`. Can be HTTP or HTTPS. | (none) |
-|ignoreSystemProxy   |  Ignore any proxy defined via the `HTTP_PROXY` or `HTTPS_PROXY` environment variables. Note that if a proxy has been defined using the `proxy` parameter, this one has no effect. | false |
-|caBundleFile        |  **[LINUX HTTPS ONLY]** Specifies the Certificate Authority certificate to use for validating HTTPS connections against the proxy. Useful when the proxy uses a self-signed certificate. **The certificate file must be in the PEM format**. If not specified, then the operating system's CA list is used. Only used when `validateProxyCerts` is `true`. | (none) |
-|caBundleDir         |  **[LINUX HTTPS ONLY]** Specifies a folder containing one or more Certificate Authority certificates ot use for validating HTTPS connections against the proxy. Useful when the proxy uses a self-signed certificate. **Only certificate files in the PEM format and \*.pem extension will be considered**. If not specified, then the operating system's CA list is used. Only used when `validateProxyCerts` is `true`.  | (none) |
-|validateProxyCerts  |  **[HTTPS ONLY]** When using a HTTPS proxy, the proxy certificates are validated by default when establishing a HTTPS connection. To disable the proxy certificate validation, set `validateProxyCerts` to `false` (insecure) | true |
+| Key                | Description                                                                                                                                                                                                                                                                                                                                                                                                              | Default                               |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| endpoint           | The endpoint you send data to                                                                                                                                                                                                                                                                                                                                                                                            | `https://log-api.newrelic.com/log/v1` |
+| apiKey             | Your New Relic Insights Insert key                                                                                                                                                                                                                                                                                                                                                                                       | (none)                                |
+| licenseKey         | Your New Relic License key                                                                                                                                                                                                                                                                                                                                                                                               | (none)                                |
+| maxBufferSize      | **[Deprecated since 1.3.0]** The maximum size the payloads sent in bytes                                                                                                                                                                                                                                                                                                                                                 | 256000                                |
+| maxRecords         | **[Deprecated since 1.3.0]** The maximum number of records to send at a time                                                                                                                                                                                                                                                                                                                                             | 1024                                  |
+| proxy              | Optional proxy to communicate with New Relic, overrides any environment-defined one. Must follow the format `https://user:password@hostname:port`. Can be HTTP or HTTPS.                                                                                                                                                                                                                                                 | (none)                                |
+| ignoreSystemProxy  | Ignore any proxy defined via the `HTTP_PROXY` or `HTTPS_PROXY` environment variables. Note that if a proxy has been defined using the `proxy` parameter, this one has no effect.                                                                                                                                                                                                                                         | false                                 |
+| caBundleFile       | **[LINUX HTTPS ONLY]** Specifies the Certificate Authority certificate to use for validating HTTPS connections against the proxy. Useful when the proxy uses a self-signed certificate. **The certificate file must be in the PEM format**. If not specified, then the operating system's CA list is used. Only used when `validateProxyCerts` is `true`.                                                                | (none)                                |
+| caBundleDir        | **[LINUX HTTPS ONLY]** Specifies a folder containing one or more Certificate Authority certificates ot use for validating HTTPS connections against the proxy. Useful when the proxy uses a self-signed certificate. **Only certificate files in the PEM format and \*.pem extension will be considered**. If not specified, then the operating system's CA list is used. Only used when `validateProxyCerts` is `true`. | (none)                                |
+| validateProxyCerts | **[HTTPS ONLY]** When using a HTTPS proxy, the proxy certificates are validated by default when establishing a HTTPS connection. To disable the proxy certificate validation, set `validateProxyCerts` to `false` (insecure)                                                                                                                                                                                             | true                                  |
 
 For information on how to find your New Relic Insights Insert key, take a look at the
 documentation [here](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register).
@@ -137,13 +148,15 @@ Set `endpoint` to `https://log-api.eu.newrelic.com/log/v1`.
 This plugin comes with a Dockerfile and sample config that will let you get started with the plugin fairly easily.
 
 ### Environment Variables
-| Key | Description | Required |
-|-----|-------------| -----|
-|API_KEY     | Your New Relic Insights Insert Key | Yes (either License Key or API Key is required) |
-|FILE_PATH   | A path or glob to the file or files you wish to tail | Yes |
-|LICENSE_KEY | Your New Relic License key | Yes (either License Key or API Key is required) |
+
+| Key         | Description                                          | Required                                        |
+| ----------- | ---------------------------------------------------- | ----------------------------------------------- |
+| API_KEY     | Your New Relic Insights Insert Key                   | Yes (either License Key or API Key is required) |
+| FILE_PATH   | A path or glob to the file or files you wish to tail | Yes                                             |
+| LICENSE_KEY | Your New Relic License key                           | Yes (either License Key or API Key is required) |
 
 ### Docker Example
+
 Within the root of the project run the following. You can supplement the image name and tag as you see fit.
 
 ```
@@ -152,13 +165,28 @@ docker run -e "FILE_PATH=/var/log/*" -e "API_KEY=<YOUR-API-KEY>" <YOUR-IMAGE-NAM
 ```
 
 ### Retry logic
-For recoverables error, the plugin is set to send a Retry order to Fluent Bit to flush data again. By default the `Retry_Limit` is set to 1 attempt. But can be [overwritten manually](https://docs.fluentbit.io/manual/administration/scheduling-and-retries). 
 
-| Key | Value | Description |
-|-----|-------| ------------|
-| Retry_Limit | N | Integer value to set the maximum number of retries allowed. N must be >= 1 (default: 1) | 
+For recoverables error, the plugin is set to send a Retry order to Fluent Bit to flush data again. By default the `Retry_Limit` is set to 1 attempt. But can be [overwritten manually](https://docs.fluentbit.io/manual/administration/scheduling-and-retries).
+
+| Key         | Value | Description                                                                                                          |
+| ----------- | ----- | -------------------------------------------------------------------------------------------------------------------- |
+| Retry_Limit | N     | Integer value to set the maximum number of retries allowed. N must be >= 1 (default: 1)                              |
 | Retry_Limit | False | When Retry_Limit is set to False, means that there is not limit for the number of retries that the Scheduler can do. |
 
+## Testing docker images
+
+For build and test docker image just run `bash test.sh`. Bear in mind that docker-compose is required to run the tests.
+
+Testing steps are:
+
+1. Create test/testdata folder for store temporal configurations and the log file
+2. Build the image (default dockerfile is ./Dockerfile but you can set the one you want with DOCKERFILE env)
+3. Run the docker-compose (./test/docker-compose.yml) with the following instances:
+   - A mockserver with expectations from ./test/expectations.json
+   - The built docker image with fluent bit configuration from ./test/fluent-bit.conf
+4. Send some logs
+5. Verify that logs are reaching the mockserver
+6. Cleanup
 
 ## Community
 
@@ -173,4 +201,5 @@ If you believe you have found a security vulnerability in this project or any of
 If you would like to contribute to this project, review [these guidelines](https://opensource.newrelic.com/code-of-conduct/).
 
 ## License
+
 newrelic-fluent-bit-output is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.

--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,10 @@ function check_mockserver {
 mkdir ./test/testdata || true
 touch ./test/testdata/fbtest.log
 
-# Initialize
+# We should skip re-building the docker image en GH
+# since we already build it on previous step so
+# we're usign the CI env var that GH set to true for
+# every job in the pipeline
 if [ ${CI:-no} = "no" ]; then
   echo "Building docker image"
   docker build -f ${DOCKERFILE:-Dockerfile} -t fb-output-plugin .

--- a/test.sh
+++ b/test.sh
@@ -20,13 +20,15 @@ clean_up () {
 trap clean_up EXIT
 
 function check_logs {
-  curl -X PUT -s --fail "http://localhost:1080/mockserver/verify" -d @test/verification.json
-  return $?
+  curl -X PUT -s --fail "http://localhost:1080/mockserver/verify" -d @test/verification.json >> /dev/null
+  RESULT=$?
+  return $RESULT
 }
 
 function check_mockserver {
   curl -X PUT -s --fail "http://localhost:1080/mockserver/status" >> /dev/null
-  return $?
+  RESULT=$?
+  return $RESULT
 }
 
 # Create testdata folder and log file
@@ -45,12 +47,12 @@ docker-compose -f ./test/docker-compose.yml up -d
 # Waiting mockserver to be ready
 max_retry=10
 counter=0
-while ! check_mockserver
+until check_mockserver
 do
   echo "Waiting mockserver to be ready. Trying again in 2s. Try #$counter"
   sleep 2
-  [[ counter -eq $max_retry ]] && echo "Mockserver failed to start!" && exit 1
-  ((counter++))
+  [[ $counter -eq $max_retry ]] && echo "Mockserver failed to start!" && exit 1
+  counter+=1
 done
 
 # Sending some logs
@@ -67,11 +69,11 @@ touch ./test/testdata/fbtest.log
 
 max_retry=10
 counter=0
-while ! check_logs
+until check_logs
 do
   echo "Logs not found trying again in 2s. Try #$counter"
   sleep 2
-  [[ counter -eq $max_retry ]] && echo "Logs do not reach the server!" && exit 1
-  ((counter++))
+  [[ $counter -eq $max_retry ]] && echo "Logs do not reach the server!" && exit 1
+  counter+=1
 done
 echo "Success!"

--- a/test.sh
+++ b/test.sh
@@ -56,8 +56,14 @@ done
 # Sending some logs
 echo "Sending logs an waiting for arrive"
 for i in {1..5}; do
-echo "Hello!\n" >> ./test/testdata/fbtest.log
+  echo "Hello!" >> ./test/testdata/fbtest.log
 done
+
+# This updates the modified date of the log file, it should
+# be updated with the echo but looks like it doesn't. A reason
+# could be that we're putting this file as a volume and writting
+# small changes so fast, if we add more echoes it works as well.
+touch ./test/testdata/fbtest.log
 
 max_retry=10
 counter=0

--- a/test.sh
+++ b/test.sh
@@ -25,11 +25,10 @@ function check_logs {
 mkdir ./test/testdata || true
 touch ./test/testdata/fbtest.log
 
-# Initialize
-if [ ${SKIP_BUILD:-no} = "no" ]; then
-  echo "Building docker image"
-  docker build -f ${DOCKERFILE:-Dockerfile} -t fb-output-plugin .
-fi
+echo "Building docker image"
+docker build -f ${DOCKERFILE:-Dockerfile} -t fb-output-plugin .
+docker pull fb-output-plugin --cache-from
+
 echo "Starting docker compose"
 docker-compose -f ./test/docker-compose.yml up -d
 sleep 5

--- a/test.sh
+++ b/test.sh
@@ -4,10 +4,10 @@ clean_up () {
     ARG=$?
 
     if [[ $ARG -ne 0 ]]; then
-      echo "Test failed showing docker logs"
-      echo "\n- Mockserver\n"
+      echo "Test failed, showing docker logs"
+      echo "- Mockserver"
       docker-compose -f ./test/docker-compose.yml logs mockserver
-      echo "\n- Fluent Bit\n"
+      echo "- Fluent Bit"
       docker-compose -f ./test/docker-compose.yml logs newrelic-fluent-bit-output
     fi
 
@@ -24,6 +24,11 @@ function check_logs {
   return $?
 }
 
+function check_mockserver {
+  curl -X PUT -s --fail "http://localhost:1080/mockserver/status" >> /dev/null
+  return $?
+}
+
 # Create testdata folder and log file
 mkdir ./test/testdata || true
 touch ./test/testdata/fbtest.log
@@ -37,19 +42,30 @@ fi
 echo "Starting docker compose"
 docker-compose -f ./test/docker-compose.yml up -d
 
+# Waiting mockserver to be ready
+max_retry=10
+counter=0
+while ! check_mockserver
+do
+  echo "Waiting mockserver to be ready. Trying again in 2s. Try #$counter"
+  sleep 2
+  [[ counter -eq $max_retry ]] && echo "Mockserver failed to start!" && exit 1
+  ((counter++))
+done
+
 # Sending some logs
 echo "Sending logs an waiting for arrive"
 for i in {1..5}; do
 echo "Hello!\n" >> ./test/testdata/fbtest.log
 done
 
-max_retry=3
+max_retry=10
 counter=0
 while ! check_logs
 do
-  echo "Logs not found trying again in 5s. Try #$counter"
-  sleep 5
-  [[ counter -eq $max_retry ]] && echo "Failed!" && exit 1
+  echo "Logs not found trying again in 2s. Try #$counter"
+  sleep 2
+  [[ counter -eq $max_retry ]] && echo "Logs do not reach the server!" && exit 1
   ((counter++))
 done
 echo "Success!"

--- a/test.sh
+++ b/test.sh
@@ -25,9 +25,11 @@ function check_logs {
 mkdir ./test/testdata || true
 touch ./test/testdata/fbtest.log
 
-echo "Building docker image"
-docker build -f ${DOCKERFILE:-Dockerfile} -t fb-output-plugin .
-docker pull fb-output-plugin --cache-from
+# Initialize
+if [ ${SKIP_BUILD:-no} = "no" ]; then
+  echo "Building docker image"
+  docker build -f ${DOCKERFILE:-Dockerfile} -t fb-output-plugin .
+fi
 
 echo "Starting docker compose"
 docker-compose -f ./test/docker-compose.yml up -d

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+clean_up () {
+    ARG=$?
+
+    echo "Cleaning up"
+    rm -r ./test/testdata || true
+    docker-compose -f ./test/docker-compose.yml down
+
+    exit $ARG
+}
+trap clean_up EXIT
+
+function check_logs {
+  echo "Hello!" >> ./test/testdata/fbtest.log
+  curl -X PUT -s --fail "http://localhost:1080/mockserver/verify" -d '{
+    "httpRequest": {
+      "path": "/log/v1"
+    }
+  }'
+  return $?
+}
+
+# Create testdata folder and log file
+mkdir ./test/testdata || true
+touch ./test/testdata/fbtest.log
+
+# Initialize
+if [ ${SKIP_BUILD:-no} = "no" ]; then
+  echo "Building docker image"
+  docker build -f ${DOCKERFILE:-Dockerfile} -t fb-output-plugin .
+fi
+echo "Starting docker compose"
+docker-compose -f ./test/docker-compose.yml up -d
+sleep 5
+
+# Wait logs to arrive
+echo "Sending logs an waiting for arrive"
+echo "Hello!" >> ./test/testdata/fbtest.log
+sleep 1
+
+max_retry=10
+counter=0
+while ! check_logs
+do
+  echo "Logs not found trying again in 5s. Try #$counter"
+  sleep 5
+  [[ counter -eq $max_retry ]] && echo "Failed!" && exit 1
+  ((counter++))
+done
+echo "Success!"

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,14 @@ set -e
 clean_up () {
     ARG=$?
 
+    if [[ $ARG -ne 0 ]]; then
+      echo "Test failed showing docker logs"
+      echo "\n- Mockserver\n"
+      docker-compose -f ./test/docker-compose.yml logs mockserver
+      echo "\n- Fluent Bit\n"
+      docker-compose -f ./test/docker-compose.yml logs newrelic-fluent-bit-output
+    fi
+
     echo "Cleaning up"
     rm -r ./test/testdata || true
     docker-compose -f ./test/docker-compose.yml down
@@ -12,12 +20,7 @@ clean_up () {
 trap clean_up EXIT
 
 function check_logs {
-  echo "Hello!" >> ./test/testdata/fbtest.log
-  curl -X PUT -s --fail "http://localhost:1080/mockserver/verify" -d '{
-    "httpRequest": {
-      "path": "/log/v1"
-    }
-  }'
+  curl -X PUT -s --fail "http://localhost:1080/mockserver/verify" -d @test/verification.json
   return $?
 }
 
@@ -26,21 +29,21 @@ mkdir ./test/testdata || true
 touch ./test/testdata/fbtest.log
 
 # Initialize
-if [ ${SKIP_BUILD:-no} = "no" ]; then
+if [ ${CI:-no} = "no" ]; then
   echo "Building docker image"
   docker build -f ${DOCKERFILE:-Dockerfile} -t fb-output-plugin .
 fi
 
 echo "Starting docker compose"
 docker-compose -f ./test/docker-compose.yml up -d
-sleep 5
 
-# Wait logs to arrive
+# Sending some logs
 echo "Sending logs an waiting for arrive"
-echo "Hello!" >> ./test/testdata/fbtest.log
-sleep 1
+for i in {1..5}; do
+echo "Hello!\n" >> ./test/testdata/fbtest.log
+done
 
-max_retry=10
+max_retry=3
 counter=0
 while ! check_logs
 do

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -13,8 +13,6 @@ services:
 
   newrelic-fluent-bit-output:
     image: fb-output-plugin
-    depends_on:
-      - mockserver
     volumes:
       - "./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf"
       - "./testdata/fbtest.log:/var/log/fbtest.log"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+services:
+  mockserver:
+    image: mockserver/mockserver
+    volumes:
+      - "./expectations.json:/tmp/expectations.json"
+    ports:
+      - 1080:1080
+    environment:
+      MOCKSERVER_WATCH_INITIALIZATION_JSON: "true"
+      MOCKSERVER_INITIALIZATION_JSON_PATH: /tmp/expectations.json
+
+  newrelic-fluent-bit-output:
+    image: fb-output-plugin
+    depends_on:
+      - mockserver
+    volumes:
+      - "./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf"
+      - "./testdata/fbtest.log:/var/log/fbtest.log"
+    environment:
+      FILE_PATH: /var/log/fbtest.log
+      API_KEY: some-insert-key

--- a/test/expectations.json
+++ b/test/expectations.json
@@ -2,17 +2,7 @@
   {
     "httpRequest": {
       "method": "POST",
-      "path": "/log/v1",
-      "headers": [
-        {
-          "name": "X-Insert-Key",
-          "values": ["some-insert-key"]
-        },
-        {
-          "name": "Content-Type",
-          "values": ["application/json"]
-        }
-      ]
+      "path": "/log/v1"
     },
     "httpResponse": {
       "statusCode": 202

--- a/test/expectations.json
+++ b/test/expectations.json
@@ -1,0 +1,21 @@
+[
+  {
+    "httpRequest": {
+      "method": "POST",
+      "path": "/log/v1",
+      "headers": [
+        {
+          "name": "X-Insert-Key",
+          "values": ["some-insert-key"]
+        },
+        {
+          "name": "Content-Type",
+          "values": ["application/json"]
+        }
+      ]
+    },
+    "httpResponse": {
+      "statusCode": 202
+    }
+  }
+]

--- a/test/fluent-bit.conf
+++ b/test/fluent-bit.conf
@@ -1,0 +1,15 @@
+[SERVICE]
+    Flush         1
+    Daemon        Off
+    Log_File      /dev/stdout
+
+[INPUT]
+    Name          tail
+    Path          ${FILE_PATH}
+
+[OUTPUT]
+    Name          newrelic
+    Match         *
+    apiKey        ${API_KEY}
+    licenseKey    ${LICENSE_KEY}
+    endpoint      http://mockserver:1080/log/v1

--- a/test/verification.json
+++ b/test/verification.json
@@ -1,0 +1,67 @@
+{
+  "httpRequest": {
+    "method": "POST",
+    "path": "/log/v1",
+    "headers": [
+      {
+        "name": "X-Insert-Key",
+        "values": ["some-insert-key"]
+      },
+      {
+        "name": "Content-Type",
+        "values": ["application/json"]
+      }
+    ],
+    "body": {
+      "type": "JSON",
+      "matchType": "STRICT",
+      "json": [
+        {
+          "message": "Hello!\\n",
+          "plugin": {
+            "source": "BARE-METAL",
+            "type": "fluent-bit",
+            "version": "${json-unit.any-string}"
+          },
+          "timestamp": "${json-unit.any-number}"
+        },
+        {
+          "message": "Hello!\\n",
+          "plugin": {
+            "source": "BARE-METAL",
+            "type": "fluent-bit",
+            "version": "${json-unit.any-string}"
+          },
+          "timestamp": "${json-unit.any-number}"
+        },
+        {
+          "message": "Hello!\\n",
+          "plugin": {
+            "source": "BARE-METAL",
+            "type": "fluent-bit",
+            "version": "${json-unit.any-string}"
+          },
+          "timestamp": "${json-unit.any-number}"
+        },
+        {
+          "message": "Hello!\\n",
+          "plugin": {
+            "source": "BARE-METAL",
+            "type": "fluent-bit",
+            "version": "${json-unit.any-string}"
+          },
+          "timestamp": "${json-unit.any-number}"
+        },
+        {
+          "message": "Hello!\\n",
+          "plugin": {
+            "source": "BARE-METAL",
+            "type": "fluent-bit",
+            "version": "${json-unit.any-string}"
+          },
+          "timestamp": "${json-unit.any-number}"
+        }
+      ]
+    }
+  }
+}

--- a/test/verification.json
+++ b/test/verification.json
@@ -17,7 +17,7 @@
       "matchType": "STRICT",
       "json": [
         {
-          "message": "Hello!\\n",
+          "message": "Hello!",
           "plugin": {
             "source": "BARE-METAL",
             "type": "fluent-bit",
@@ -26,7 +26,7 @@
           "timestamp": "${json-unit.any-number}"
         },
         {
-          "message": "Hello!\\n",
+          "message": "Hello!",
           "plugin": {
             "source": "BARE-METAL",
             "type": "fluent-bit",
@@ -35,7 +35,7 @@
           "timestamp": "${json-unit.any-number}"
         },
         {
-          "message": "Hello!\\n",
+          "message": "Hello!",
           "plugin": {
             "source": "BARE-METAL",
             "type": "fluent-bit",
@@ -44,7 +44,7 @@
           "timestamp": "${json-unit.any-number}"
         },
         {
-          "message": "Hello!\\n",
+          "message": "Hello!",
           "plugin": {
             "source": "BARE-METAL",
             "type": "fluent-bit",
@@ -53,7 +53,7 @@
           "timestamp": "${json-unit.any-number}"
         },
         {
-          "message": "Hello!\\n",
+          "message": "Hello!",
           "plugin": {
             "source": "BARE-METAL",
             "type": "fluent-bit",


### PR DESCRIPTION
Adding tests for docker images on the pipeline, also updated the README but here are the steps followed by test scripts:

1. Create test/testdata folder for store temporal configurations and the log file
2. Build the image (default dockerfile is ./Dockerfile but you can set the one you want with DOCKERFILE env)
3. Run the docker-compose (./test/docker-compose.yml) with the following instances:
   - A mockserver with expectations from ./test/expectations.json
   - The built docker image with fluent bit configuration from ./test/fluent-bit.conf
4. Send some logs
5. Verify that logs are reaching the mockserver
6. Cleanup
