### PR TITLE
Added Dockerfile for building ARM compatible container image

### DIFF
--- a/Dockerfile_arm64
+++ b/Dockerfile_arm64
@@ -1,0 +1,20 @@
+FROM golang:1.11 AS builder
+
+WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
+
+COPY Makefile go.* *.go /go/src/github.com/newrelic/newrelic-fluent-bit-output/
+COPY config/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/config
+COPY nrclient/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/nrclient
+COPY record/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/record
+COPY utils/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/utils
+
+ENV SOURCE docker
+RUN go get github.com/fluent/fluent-bit-go/output
+RUN make linux-arm64
+
+FROM fluent/fluent-bit:1.8.1
+
+COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-arm64-*.so /fluent-bit/bin/out_newrelic.so
+COPY *.conf /fluent-bit/etc/
+
+CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf", "-e", "/fluent-bit/bin/out_newrelic.so"]

--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ docker build -t <YOUR-IMAGE-NAME>:<YOUR-TAG> .
 docker run -e "FILE_PATH=/var/log/*" -e "API_KEY=<YOUR-API-KEY>" <YOUR-IMAGE-NAME>:<YOUR-TAG>
 ```
 
+#### For buidling container image for ARM platform:
+When Build is executed on a ARM platform:
+```
+docker build -f Dockerfile_arm64 -t <YOUR-IMAGE-NAME>:<YOUR-TAG> .
+```
+When Build is executed on a non-ARM platform (with buildx):
+```
+docker buildx build --platform linux/arm64 -t <YOUR-IMAGE-NAME>:<YOUR-TAG> . --load
+```
+
 ### Retry logic
 For recoverables error, the plugin is set to send a Retry order to Fluent Bit to flush data again. By default the `Retry_Limit` is set to 1 attempt. But can be [overwritten manually](https://docs.fluentbit.io/manual/administration/scheduling-and-retries). 
 


### PR DESCRIPTION
**Newly build ARM image :** saibaldey/newrelic-fluentbit-output:1.6.1 -- https://hub.docker.com/r/saibaldey/newrelic-fluentbit-output/tags?page=1&ordering=last_updated
`docker pull saibaldey/newrelic-fluentbit-output:1.6.1`

**Startup log of new ARM image once deployed as part of NR deployments of Kubernetes:**
`-bash-4.2$ kubectl logs po/newrelic-bundle-newrelic-logging-df6gf -n newrelic
Fluent Bit v1.8.1
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/07/14 15:30:08] [ info] [engine] started (pid=1)
[2021/07/14 15:30:08] [ info] [storage] version=1.1.1, initializing...
[2021/07/14 15:30:08] [ info] [storage] in-memory
[2021/07/14 15:30:08] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/07/14 15:30:08] [ info] [cmetrics] version=0.1.1
[2021/07/14 15:30:08] [ info] [filter:kubernetes:kubernetes.1] https=1 host=kubernetes.default.svc port=443
[2021/07/14 15:30:08] [ info] [filter:kubernetes:kubernetes.1] local POD info OK
[2021/07/14 15:30:08] [ info] [filter:kubernetes:kubernetes.1] testing connectivity with API server...
[2021/07/14 15:30:13] [ warn] [filter:kubernetes:kubernetes.1] could not get meta for POD ip-172-30-35-133.us-east-2.compute.internal
[2021/07/14 15:30:13] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2021/07/14 15:30:13] [ info] [sp] stream processor started
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=13671103 watch_fd=1 name=/var/log/containers/aws-load-balancer-controller-57d8b84dc5-lgjmh_kube-system_aws-load-balancer-controller-fb7e8ae7795028784b8ccad5a4294f5b5330488af542f2eced60ce2b6aa8136e.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=38030334 watch_fd=2 name=/var/log/containers/aws-node-hgw74_kube-system_aws-node-d2aba75c8ea003e22fd0dedd70886c4a9154876c5709d8659ac9fd0f802da8ac.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=6709729 watch_fd=3 name=/var/log/containers/aws-node-hgw74_kube-system_aws-vpc-cni-init-11a34329a4eb9334f2640736adfc74a64aa3ab97519b7e3db6c185d83f9f9ad8.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=12740058 watch_fd=4 name=/var/log/containers/cluster-autoscaler-8b7486df4-c7snk_kube-system_cluster-autoscaler-df4996ab3f8f12541a6a223ecc58a1387ee2f411dea9991135c6eec232d82cf0.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=13667801 watch_fd=5 name=/var/log/containers/cni-metrics-helper-7c76bd56f8-rw6nc_kube-system_cni-metrics-helper-e4973e565af6d3d7476ba20aef35a9cf4e0526b2291d740e7c805733b3421611.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=23075084 watch_fd=6 name=/var/log/containers/coredns-5c778788f4-b7ph2_kube-system_coredns-81c508dafe5b5d6dfb32fd924ccd2173a02d38ae679a40e04b4417d578d3441b.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=20977654 watch_fd=7 name=/var/log/containers/coredns-5c778788f4-bz6dt_kube-system_coredns-13b7b69caf95f7d8be38f808c30d44da2ec106a1b4a929e9359d65950670f8db.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=36821911 watch_fd=8 name=/var/log/containers/hscam-search-claim-service-helmchart-deployment-5fb6fb86fczc2wv_mendix-qa_helmchart-44ea37e1a0e6094df5c205db360cf2555237db757d5ff7f1525f1d65e76fd894.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=37750172 watch_fd=9 name=/var/log/containers/kube-proxy-klld2_kube-system_kube-proxy-c3163d4350154fb8983fbbf1dec59ce286161cca94fb5eaced1761c571637406.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=38022131 watch_fd=10 name=/var/log/containers/newrelic-bundle-newrelic-infrastructure-l4ljx_newrelic_newrelic-infrastructure-8200cfb9df353d9319f6d735a342e958e42b2e94b46f7767e8750706c6381047.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=26517448 watch_fd=11 name=/var/log/containers/private-external-dns-dc466559d-dwvmf_kube-system_external-dns-d6860fbbe8f5f2d30693be94390870017beb11e57a39e0a0b6bf1c32a7116521.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=10657820 watch_fd=12 name=/var/log/containers/public-external-dns-764fd45f65-qhqk9_kube-system_external-dns-8d708d3dc9260bf04b83d39030f1e556b243ab89f49fbcf8519c98272adb3aad.log
[2021/07/14 15:30:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=40393798 watch_fd=13 name=/var/log/containers/newrelic-bundle-newrelic-logging-df6gf_newrelic_newrelic-logging-2a806d83edf486e079364aee2248710d0c683d93fd62e3f0ff96f22dadd8a064.log
2021/07/14 15:30:14 [INFO] Request accepted.
2021/07/14 15:30:15 [INFO] Request accepted.
2021/07/14 15:30:16 [INFO] Request accepted.
2021/07/14 15:30:17 [INFO] Request accepted.
2021/07/14 15:30:18 [INFO] Request accepted.
2021/07/14 15:30:19 [INFO] Request accepted.
2021/07/14 15:30:20 [INFO] Request accepted.
2021/07/14 15:30:21 [INFO] Request accepted.`