### PR TITLE
feat: build and push output arm64 docker image

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -87,13 +87,13 @@ jobs:
         uses: docker/build-push-action@v2
         env:
           DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output
-          IMAGE_TAG: ${{ env.VERSION }}
+          IMAGE_TAG: ${{ env.VERSION }}-debug
         with:
           context: ./
           file: ./Dockerfile_debug
           push: true
           tags: |
-            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }}-debug
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }}
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -102,13 +102,13 @@ jobs:
         uses: docker/build-push-action@v2
         env:
           DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output
-          IMAGE_TAG: ${{ env.VERSION }}
+          IMAGE_TAG: ${{ env.VERSION }}-arm64
         with:
           context: ./
           file: ./Dockerfile_arm64
           push: true
           tags: |
-            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }}-arm64
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }}
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Build project (Linux arm64)
         run: env make linux-arm64
 
+      # The QEMU will include more platforms such as arm64 to docker buildx builder
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       # The Docker Buildx builder will be used later to leverage from the cache while building the image
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -97,6 +97,21 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          
+      - name: Build and Publish Docker arm64 image
+        uses: docker/build-push-action@v2
+        env:
+          DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output
+          IMAGE_TAG: ${{ env.VERSION }}
+        with:
+          context: ./
+          file: ./Dockerfile_arm64
+          push: true
+          tags: |
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }}-arm64
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Image digest
         run: 'echo "Published Docker image with digest: ${{ steps.docker_build.outputs.digest }}"'

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -112,6 +112,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/arm64
 
       - name: Image digest
         run: 'echo "Published Docker image with digest: ${{ steps.docker_build.outputs.digest }}"'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -90,6 +90,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/arm64
+          outputs: type=docker
 
       - name: Test Docker arm image
         run: bash test.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build project
         run: make linux-amd64
 
-      #
+      # The QEMU will include more platforms such as arm64 to docker buildx builder
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,6 +66,17 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+      
+      - name: Build Docker arm64 image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile_arm64
+          push: false
+          tags: 'pr-tag'
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Build Docker image for Firelens
         uses: docker/build-push-action@v2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -75,20 +75,23 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      
+
+      - name: Test Docker debug image
+        run: bash test.sh
+
       - name: Build Docker arm64 image
         uses: docker/build-push-action@v2
         with:
           context: ./
           file: ./Dockerfile_arm64
           push: false
-          tags: 'pr-tag'
+          tags: fb-output-plugin
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/arm64
 
-      - name: Test Docker debug image
+      - name: Test Docker arm image
         run: bash test.sh
 
       - name: Build Docker image for Firelens

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,6 +32,10 @@ jobs:
       - name: Build project
         run: make linux-amd64
 
+      #
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       # The Docker Buildx builder will be used later to leverage from the cache while building the image
       - name: Set up Docker Buildx
         id: buildx
@@ -77,6 +81,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/arm64
 
       - name: Build Docker image for Firelens
         uses: docker/build-push-action@v2

--- a/Dockerfile_arm64
+++ b/Dockerfile_arm64
@@ -1,0 +1,20 @@
+FROM golang:1.11 AS builder
+
+WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
+
+COPY Makefile go.* *.go /go/src/github.com/newrelic/newrelic-fluent-bit-output/
+COPY config/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/config
+COPY nrclient/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/nrclient
+COPY record/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/record
+COPY utils/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/utils
+
+ENV SOURCE docker
+RUN go get github.com/fluent/fluent-bit-go/output
+RUN make linux-arm64
+
+FROM fluent/fluent-bit:1.8.1
+
+COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-arm64-*.so /fluent-bit/bin/out_newrelic.so
+COPY *.conf /fluent-bit/etc/
+
+CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf", "-e", "/fluent-bit/bin/out_newrelic.so"]

--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ docker build -t <YOUR-IMAGE-NAME>:<YOUR-TAG> .
 docker run -e "FILE_PATH=/var/log/*" -e "API_KEY=<YOUR-API-KEY>" <YOUR-IMAGE-NAME>:<YOUR-TAG>
 ```
 
+#### For buidling container image for ARM platform:
+When Build is executed on a ARM platform:
+```
+docker build -f Dockerfile_arm64 -t <YOUR-IMAGE-NAME>:<YOUR-TAG> .
+```
+When Build is executed on a non-ARM platform (with buildx):
+```
+docker buildx build --platform linux/arm64 -t <YOUR-IMAGE-NAME>:<YOUR-TAG> . --load
+```
+
 ### Retry logic
 For recoverables error, the plugin is set to send a Retry order to Fluent Bit to flush data again. By default the `Retry_Limit` is set to 1 attempt. But can be [overwritten manually](https://docs.fluentbit.io/manual/administration/scheduling-and-retries). 
 

--- a/test.sh
+++ b/test.sh
@@ -44,6 +44,8 @@ if [ ${CI:-no} = "no" ]; then
   docker build -f ${DOCKERFILE:-Dockerfile} -t fb-output-plugin .
 fi
 
+echo "Using docker image for: $(docker image inspect fb-output-plugin --format \"{{.Architecture}}\")"
+
 echo "Starting docker compose"
 docker-compose -f ./test/docker-compose.yml up -d
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.6.1"
+const VERSION = "1.7.0"


### PR DESCRIPTION
From @saibaldey [PR#79](https://github.com/newrelic/newrelic-fluent-bit-output/pull/79)

New version of output plugin v1.7.0 will provide support for arm64 docker images.

In this PR:
- New docker file will allow customers to build arm images locally
- Provide arm64 docker image support by: `docker pull newrelic/newrelic-fluentbit-output:1.7.0-arm64`