### PR TITLE
Removes verbose log

### DIFF
--- a/out_newrelic.go
+++ b/out_newrelic.go
@@ -70,7 +70,6 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 	code, err := nrClient.Send(buffer)
 	
 	if err == nil  && code == statusAccepted {
-		// log.Printf("[INFO] Request accepted.")
 		return output.FLB_OK
 	} 
 	if (err == nil && isRetriableStatusCode(code)) || (code == retriableConnectionError){

--- a/out_newrelic.go
+++ b/out_newrelic.go
@@ -70,7 +70,7 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 	code, err := nrClient.Send(buffer)
 	
 	if err == nil  && code == statusAccepted {
-		log.Printf("[INFO] Request accepted.")
+		// log.Printf("[INFO] Request accepted.")
 		return output.FLB_OK
 	} 
 	if (err == nil && isRetriableStatusCode(code)) || (code == retriableConnectionError){

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.8.0"
+const VERSION = "1.8.1"


### PR DESCRIPTION
Drop log line of the happy path. 
Solves this issue: https://github.com/newrelic/newrelic-fluent-bit-output/issues/87