### PR TITLE
[LOGGING-5582] Build Windows Server 2019 LTSC Docker image

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -144,6 +144,14 @@ jobs:
       - name: Inspect published Docker Firelens image
         run: docker buildx imagetools inspect 533243300146.dkr.ecr.us-east-2.amazonaws.com/newrelic/logging-firelens-fluentbit:${{ env.VERSION }}
 
+      - name: Build and Publish Docker image for Windows
+        env:
+          DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output
+          IMAGE_TAG: ${{ env.VERSION }}-windows
+        run: |
+          docker build -f Dockerfile.windows -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} .
+          docker push ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} .
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -144,14 +144,6 @@ jobs:
       - name: Inspect published Docker Firelens image
         run: docker buildx imagetools inspect 533243300146.dkr.ecr.us-east-2.amazonaws.com/newrelic/logging-firelens-fluentbit:${{ env.VERSION }}
 
-      - name: Build and Publish Docker image for Windows
-        env:
-          DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output
-          IMAGE_TAG: ${{ env.VERSION }}-windows
-        run: |
-          docker build -f Dockerfile.windows -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} .
-          docker push ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} .
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -212,3 +204,51 @@ jobs:
           asset_path: ./out_newrelic-linux-arm-${{ env.VERSION }}.so
           asset_name: out_newrelic-linux-arm-${{ env.VERSION }}.so
           asset_content_type: application/octet-stream
+
+  windows-docker-images:
+    name:  ${{ matrix.name }} Docker image generation and publishing
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        include:
+          # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
+          - name: Windows Server LTSC 2019
+            windowsImageTag: ltsc2019
+            imageTagSuffix: windows-ltsc-2019
+          - name: Windows Server SAC 1809
+            windowsImageTag: "1809"
+            imageTagSuffix: windows-sac-1809
+          - name: Windows Server SAC 1909
+            windowsImageTag: "1909"
+            imageTagSuffix: windows-sac-1909
+          - name: Windows Server SAC 2004
+            windowsImageTag: "2004"
+            imageTagSuffix: windows-sac-2004
+          - name: Windows Server SAC 20H2
+            windowsImageTag: 20H2
+            imageTagSuffix: windows-sac-20H2
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Determine new plugin version
+        run: |
+          VERSION=$(cat version.go | grep VERSION | awk '{gsub(/"/, "", $4); print $4}')
+          echo "Determined version: $VERSION"
+          # After the following command, the VERSION variable is available via the "env" command
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and Publish Docker image for ${{ matrix.name }}
+        env:
+          DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output
+          IMAGE_TAG: ${{ env.VERSION }}-${{ matrix.imageTagSuffix }}
+        run: |
+          docker build -f Dockerfile.windows -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} --build-arg WINDOWS_VERSION=${{ matrix.windowsImageTag }} .
+          docker push ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} .

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -207,7 +207,7 @@ jobs:
 
   windows-docker-images:
     name:  ${{ matrix.name }} Docker image generation and publishing
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
         include:

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -207,26 +207,18 @@ jobs:
 
   windows-docker-images:
     name:  ${{ matrix.name }} Docker image generation and publishing
-    runs-on: windows-2022
+    # Right now, the windows-2019 worker offerred by GitHub is based on ltsc2019/10.0.17763.2183, so it can only compile containers running this specific version and compilation number of the OS.
+    # We aim to support (but right now, we can only support LTSC2019 using GitHub actions): https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
+    # More info: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#choose_your_windows_server_node_image
+    # Tag reference: https://hub.docker.com/_/microsoft-windows-servercore
+    # Compatibility matrix: https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
+    runs-on: windows-2019
     strategy:
       matrix:
         include:
-          # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
-          - name: Windows Server LTSC 2019
+          - name: Windows Server 2019 (LTSC)
             windowsImageTag: ltsc2019-amd64
             imageTagSuffix: windows-ltsc-2019
-          - name: Windows Server SAC 1809
-            windowsImageTag: 1809-amd64
-            imageTagSuffix: windows-sac-1809
-          - name: Windows Server SAC 1909
-            windowsImageTag: 1909-amd64
-            imageTagSuffix: windows-sac-1909
-          - name: Windows Server SAC 2004
-            windowsImageTag: 2004-amd64
-            imageTagSuffix: windows-sac-2004
-          - name: Windows Server SAC 20H2
-            windowsImageTag: 20H2-amd64
-            imageTagSuffix: windows-sac-20H2
 
     steps:
       - name: Checkout code

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -213,19 +213,19 @@ jobs:
         include:
           # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
           - name: Windows Server LTSC 2019
-            windowsImageTag: ltsc2019
+            windowsImageTag: ltsc2019-amd64
             imageTagSuffix: windows-ltsc-2019
           - name: Windows Server SAC 1809
-            windowsImageTag: "1809"
+            windowsImageTag: 1809-amd64
             imageTagSuffix: windows-sac-1809
           - name: Windows Server SAC 1909
-            windowsImageTag: "1909"
+            windowsImageTag: 1909-amd64
             imageTagSuffix: windows-sac-1909
           - name: Windows Server SAC 2004
-            windowsImageTag: "2004"
+            windowsImageTag: 2004-amd64
             imageTagSuffix: windows-sac-2004
           - name: Windows Server SAC 20H2
-            windowsImageTag: 20H2
+            windowsImageTag: 20H2-amd64
             imageTagSuffix: windows-sac-20H2
 
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,6 @@ on: [pull_request]
 
 jobs:
   unit-tests:
-    if: ${{ false }}  # disable for now
     name: CI - Tests and Build
     runs-on: ubuntu-18.04
 
@@ -33,7 +32,6 @@ jobs:
         run: make linux/amd64
 
   docker-ci:
-    if: ${{ false }}  # disable for now
     name: CI - Docker image build (${{ matrix.name }})
     runs-on: ubuntu-18.04
     services:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -127,6 +127,6 @@ jobs:
       - name: Build container for ${{ matrix.name }}
         env:
           DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output
-          IMAGE_TAG: ${{ env.VERSION }}-${{ matrix.imageTagSuffix }}
+          IMAGE_TAG: development-${{ matrix.imageTagSuffix }}
         run: |
           docker build -f Dockerfile.windows -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} --build-arg WINDOWS_VERSION=${{ matrix.windowsImageTag }} .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -125,5 +125,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build container for ${{ matrix.name }}
+        env:
+          DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output
+          IMAGE_TAG: ${{ env.VERSION }}-${{ matrix.imageTagSuffix }}
         run: |
           docker build -f Dockerfile.windows -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} --build-arg WINDOWS_VERSION=${{ matrix.windowsImageTag }} .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   unit-tests:
+    if: ${{ false }}  # disable for now
     name: CI - Tests and Build
     runs-on: ubuntu-18.04
 
@@ -32,6 +33,7 @@ jobs:
         run: make linux/amd64
 
   docker-ci:
+    if: ${{ false }}  # disable for now
     name: CI - Docker image build (${{ matrix.name }})
     runs-on: ubuntu-18.04
     services:
@@ -96,3 +98,15 @@ jobs:
 
       - name: Test Docker image (${{ matrix.name }})
         run: bash test.sh
+
+  docker-windows-ci:
+    name: CI - Docker image for Windows build
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build container
+        run: |
+          docker build -f Dockerfile.windows .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,7 +99,7 @@ jobs:
 
   docker-windows-ci:
     name:  CI - Docker image for ${{ matrix.name }} 
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
         include:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -98,13 +98,32 @@ jobs:
         run: bash test.sh
 
   docker-windows-ci:
-    name: CI - Docker image for Windows build
+    name:  CI - Docker image for ${{ matrix.name }} 
     runs-on: windows-2019
+    strategy:
+      matrix:
+        include:
+          # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
+          - name: Windows Server LTSC 2019
+            windowsImageTag: ltsc2019
+            imageTagSuffix: windows-ltsc-2019
+          - name: Windows Server SAC 1809
+            windowsImageTag: "1809"
+            imageTagSuffix: windows-sac-1809
+          - name: Windows Server SAC 1909
+            windowsImageTag: "1909"
+            imageTagSuffix: windows-sac-1909
+          - name: Windows Server SAC 2004
+            windowsImageTag: "2004"
+            imageTagSuffix: windows-sac-2004
+          - name: Windows Server SAC 20H2
+            windowsImageTag: 20H2
+            imageTagSuffix: windows-sac-20H2
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Build container
+      - name: Build container for ${{ matrix.name }}
         run: |
-          docker build -f Dockerfile.windows .
+          docker build -f Dockerfile.windows -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} --build-arg WINDOWS_VERSION=${{ matrix.windowsImageTag }} .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,26 +99,18 @@ jobs:
 
   docker-windows-ci:
     name:  CI - Docker image for ${{ matrix.name }} 
-    runs-on: windows-2022
+    # Right now, the windows-2019 worker offerred by GitHub is based on ltsc2019/10.0.17763.2183, so it can only compile containers running this specific version and compilation number of the OS.
+    # We aim to support (but right now, we can only support LTSC2019 using GitHub actions): https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
+    # More info: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#choose_your_windows_server_node_image
+    # Tag reference: https://hub.docker.com/_/microsoft-windows-servercore
+    # Compatibility matrix: https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
+    runs-on: windows-2019
     strategy:
       matrix:
         include:
-          # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
-          - name: Windows Server LTSC 2019
+          - name: Windows Server 2019 (LTSC)
             windowsImageTag: ltsc2019-amd64
             imageTagSuffix: windows-ltsc-2019
-          - name: Windows Server SAC 1809
-            windowsImageTag: 1809-amd64
-            imageTagSuffix: windows-sac-1809
-          - name: Windows Server SAC 1909
-            windowsImageTag: 1909-amd64
-            imageTagSuffix: windows-sac-1909
-          - name: Windows Server SAC 2004
-            windowsImageTag: 2004-amd64
-            imageTagSuffix: windows-sac-2004
-          - name: Windows Server SAC 20H2
-            windowsImageTag: 20H2-amd64
-            imageTagSuffix: windows-sac-20H2
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -105,19 +105,19 @@ jobs:
         include:
           # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
           - name: Windows Server LTSC 2019
-            windowsImageTag: ltsc2019
+            windowsImageTag: ltsc2019-amd64
             imageTagSuffix: windows-ltsc-2019
           - name: Windows Server SAC 1809
-            windowsImageTag: "1809"
+            windowsImageTag: 1809-amd64
             imageTagSuffix: windows-sac-1809
           - name: Windows Server SAC 1909
-            windowsImageTag: "1909"
+            windowsImageTag: 1909-amd64
             imageTagSuffix: windows-sac-1909
           - name: Windows Server SAC 2004
-            windowsImageTag: "2004"
+            windowsImageTag: 2004-amd64
             imageTagSuffix: windows-sac-2004
           - name: Windows Server SAC 20H2
-            windowsImageTag: 20H2
+            windowsImageTag: 20H2-amd64
             imageTagSuffix: windows-sac-20H2
 
     steps:

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,126 @@
+# escape=`
+
+ARG WINDOWS_VERSION=ltsc2019
+
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION  AS nrBuilder
+
+WORKDIR /build
+
+USER ContainerAdministrator
+
+#################################################
+# Install Chocolatey
+#################################################
+
+RUN powershell.exe Invoke-WebRequest `
+  -Uri https://chocolatey.org/install.ps1 `
+  -OutFile C:\chocolatey-install.ps1
+RUN powershell.exe `
+  -ExecutionPolicy bypass `
+  -InputFormat none `
+  -NoProfile `
+  C:\chocolatey-install.ps1
+RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+
+#################################################
+# Base Dependencies
+#################################################
+
+RUN choco install --yes --no-progress mingw git
+RUN choco install --yes --no-progress golang --version=1.12
+
+# Put the path before the other paths so that MinGW shadows Windows commands.
+RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"
+
+#################################################
+# Compile the newrelic-fluent-bit-output plugin
+#################################################
+COPY Makefile go.* *.go ./
+COPY config/ ./config
+COPY nrclient/ ./nrclient
+COPY record/ ./record
+COPY utils/ ./utils
+
+ENV SOURCE docker
+
+RUN setx CGO_ENABLED "1"
+RUN setx GOOS "windows"
+RUN setx GOARCH "amd64"
+RUN go build -buildmode=c-shared -o out_newrelic.dll .
+
+
+# -------------------------------------------------------------------------------------------------------------#
+#                                                                                                              #
+# The following contents are copied from the original Fluent Bit repository (except the last part,             #
+# where we build and copy the New Relic plugin inside the resulting runtime image), as there is no published   #
+# Docker image for it. Link:  https://github.com/fluent/fluent-bit/blob/master/dockerfiles/Dockerfile.windows  #
+#                                                                                                              #
+# -------------------------------------------------------------------------------------------------------------#
+
+#
+# Builder Image - Windows Server Core
+#
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as builder
+
+# The FLUENTBIT_VERSION ARG must be after the FROM instruction
+ARG FLUENTBIT_VERSION=1.7.0
+ARG IMAGE_CREATE_DATE
+ARG IMAGE_SOURCE_REVISION
+
+# Metadata as defined in OCI image spec annotations
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+LABEL org.opencontainers.image.title="Fluent Bit" `
+      org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
+      org.opencontainers.image.created=$IMAGE_CREATE_DATE `
+      org.opencontainers.image.version=$FLUENTBIT_VERSION `
+      org.opencontainers.image.authors="Eduardo Silva <eduardo@treasure-data.com>" `
+      org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
+      org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
+      org.opencontainers.image.vendor="Fluent Organization" `
+      org.opencontainers.image.licenses="Apache-2.0" `
+      org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
+      org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
+
+#
+# Basic setup
+#
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Write-Host ('Creating folders'); `
+    New-Item -Type Directory -Path /local; `
+    New-Item -Type Directory -Path /fluent-bit;
+
+WORKDIR /local
+
+#
+# Install Fluent Bit
+#
+RUN Write-Host ('Installing Fluent Bit'); `
+    $majorminor = ([Version]::Parse("$env:FLUENTBIT_VERSION")).toString(2); `
+    Invoke-WebRequest -Uri "https://fluentbit.io/releases/$($majorminor)/td-agent-bit-$($env:FLUENTBIT_VERSION)-win64.zip" -OutFile td-agent-bit.zip; `
+    Expand-Archive -Path td-agent-bit.zip -Destination /local/fluent-bit; `
+    Move-Item -Path /local/fluent-bit/*/* -Destination /fluent-bit/;
+
+#
+# Technique from https://github.com/StefanScherer/dockerfiles-windows/blob/master/mongo/3.6/Dockerfile
+#
+ADD https://aka.ms/vs/15/release/vc_redist.x64.exe /local/vc_redist.x64.exe
+
+RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
+    Start-Process /local/vc_redist.x64.exe -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
+    Copy-Item -Path /Windows/System32/msvcp140.dll -Destination /fluent-bit/bin/; `
+    Copy-Item -Path /Windows/System32/vccorlib140.dll -Destination /fluent-bit/bin/; `
+    Copy-Item -Path /Windows/System32/vcruntime140.dll -Destination /fluent-bit/bin/;
+
+#
+# Runtime Image - Windows Server Nano
+#
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as runtime
+
+COPY --from=builder /fluent-bit /fluent-bit
+
+RUN setx /M PATH "%PATH%;C:\fluent-bit\bin"
+
+COPY --from=nrBuilder /build/out_newrelic.dll /fluent-bit/bin/out_newrelic.dll
+
+CMD ["fluent-bit.exe", "-i", "dummy", "-o", "stdout", "-e", "/fluent-bit/bin/out_newrelic.dll"]

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -63,7 +63,7 @@ RUN go build -buildmode=c-shared -o out_newrelic.dll .
 FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as builder
 
 # The FLUENTBIT_VERSION ARG must be after the FROM instruction
-ARG FLUENTBIT_VERSION=1.7.0
+ARG FLUENTBIT_VERSION=1.8.1
 ARG IMAGE_CREATE_DATE
 ARG IMAGE_SOURCE_REVISION
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.8.1"
+const VERSION = "1.9.0"


### PR DESCRIPTION
### Description

This PR includes a new `Dockerfile.windows` file to build a Docker image for the Windows platform.

Windows container support is still very limited. There is a huge restriction: Windows Docker containers can only be built/executed on a host node running the same operating system version and compilation build as the container it builds/executes.

Right now, Kubernetes some versions, being the LTSC 2019 the recommended one. It also supports several SAC versions. However, the `windows-2019` worker that GitHub actions provides is based on LTSC 2019 / 10.0.17763.2183, and can't therefore build SAC versions. This is why, for now, we restrict the build to only happen for this Windows version.

The Dockerfile contents continue the work initiated by @andrew-lozoya, and also includes the Dockerfile contents present at the Fluent Bit repository in order to package Fluent Bit.

More references:
- Windows versions supported by each Kubernetes version: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
- Info on supported Windows node versions in GKE: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#choose_your_windows_server_node_image
- Tag reference: https://hub.docker.com/_/microsoft-windows-servercore
- Compatibility matrix: https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility