### PR TITLE
Add a low data mode that doesn't add the plugin information to the logs.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -18,7 +18,7 @@
 ## Developing cycle
 1. Write tests and production code
 2. Update the version in `version.go`
-3. Run tests: `go test`
+3. Run tests: `go test ./...`
 4. Compile the plugin: `make linux/amd64`. See [this section](#compiling-the-out_newrelic-plugin) for more details
 5. Run Fluent Bit with the plugin using the template config file: `FILE_PATH=/usr/local/var/log/test.log API_KEY=(your-api-key) BUFFER_SIZE= MAX_RECORDS= fluent-bit -c ./fluent-bit.conf -e ./out_newrelic.so`
 6. Cause a change that you've configured Fluent Bit to pick up: (`echo "FluentBitTest" >> /usr/local/var/log/test.log`)

--- a/config/config.go
+++ b/config/config.go
@@ -14,10 +14,11 @@ type PluginConfig struct {
 }
 
 type NRClientConfig struct {
-	Endpoint   string
-	ApiKey     string
-	LicenseKey string
-	UseApiKey  bool
+	Endpoint    string
+	ApiKey      string
+	LicenseKey  string
+	UseApiKey   bool
+	LowDataMode bool
 }
 
 type ProxyConfig struct {
@@ -73,6 +74,8 @@ func parseNRClientConfig(ctx unsafe.Pointer) (cfg NRClientConfig, err error) {
 	}
 
 	cfg.UseApiKey = len(cfg.ApiKey) > 0
+
+	cfg.LowDataMode, err = optBool(ctx, "lowDataMode", false)
 
 	return
 }

--- a/nrclient/nrclient.go
+++ b/nrclient/nrclient.go
@@ -40,6 +40,10 @@ func NewNRClient(cfg config.NRClientConfig, proxyCfg config.ProxyConfig) (*NRCli
 	return nrClient, nil
 }
 
+func (nrClient *NRClient) InLowDataMode() (bool) {
+	return nrClient.config.LowDataMode
+}
+
 func (nrClient *NRClient) Send(logRecords []record.LogRecord) (int, error) {
 	payloads, err := record.PackageRecords(logRecords)
 	if err != nil {

--- a/record/record.go
+++ b/record/record.go
@@ -21,7 +21,7 @@ type PackagedRecords *bytes.Buffer
 
 // RemapRecord takes a log record emitted by FluentBit, parses it into a NewRelic LogRecord
 // domain type and performs several key name re-mappings.
-func RemapRecord(inputRecord FluentBitRecord, inputTimestamp interface{}, pluginVersion string) (outputRecord LogRecord) {
+func RemapRecord(inputRecord FluentBitRecord, inputTimestamp interface{}, pluginVersion string, omitPlugin bool) (outputRecord LogRecord) {
 	outputRecord = make(map[string]interface{})
 	outputRecord = parseRecord(inputRecord)
 
@@ -41,7 +41,7 @@ func RemapRecord(inputRecord FluentBitRecord, inputTimestamp interface{}, plugin
 	if !ok {
 		source = "BARE-METAL"
 	}
-	if _, ok = outputRecord["plugin"]; !ok {
+	if _, ok = outputRecord["plugin"]; !ok && !omitPlugin {
 		outputRecord["plugin"] = map[string]string{
 			"type":    "fluent-bit",
 			"version": pluginVersion,

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Out New Relic", func() {
 				time.Now(),
 			}
 			inputMap["log"] = "message"
-			foundOutput := RemapRecord(inputMap, inputTimestamp, pluginVersion)
+			foundOutput := RemapRecord(inputMap, inputTimestamp, pluginVersion, false)
 			Expect(foundOutput["message"]).To(Equal("message"))
 			Expect(foundOutput["log"]).To(BeNil())
 			Expect(foundOutput["timestamp"]).To(Equal(inputTimestamp.(output.FLBTime).UnixNano() / 1000000))
@@ -59,9 +59,19 @@ var _ = Describe("Out New Relic", func() {
 			inputMap["plugin"] = map[string]string{
 				"type": expectedType,
 			}
-			foundOutput := RemapRecord(inputMap, inputTimestamp, pluginVersion)
+			foundOutput := RemapRecord(inputMap, inputTimestamp, pluginVersion,false)
 			pluginMap := foundOutput["plugin"].(map[string]string)
 			Expect(pluginMap["type"]).To(Equal(expectedType))
+		})
+
+		It("Doesn't add plugin information if in low data mode", func() {
+			inputMap := make(FluentBitRecord)
+			var inputTimestamp interface{}
+			inputTimestamp = output.FLBTime{
+				time.Now(),
+			}
+			foundOutput := RemapRecord(inputMap, inputTimestamp, pluginVersion,true)
+			Expect(foundOutput["plugin"]).To(BeNil())
 		})
 
 		It("sets the source if it is included as an environment variable", func() {
@@ -73,7 +83,7 @@ var _ = Describe("Out New Relic", func() {
 			expectedSource := "docker"
 			inputMap["log"] = "message"
 			os.Setenv("SOURCE", expectedSource)
-			foundOutput := RemapRecord(inputMap, inputTimestamp, pluginVersion)
+			foundOutput := RemapRecord(inputMap, inputTimestamp, pluginVersion, false)
 			pluginMap := foundOutput["plugin"].(map[string]string)
 			Expect(pluginMap["source"]).To(Equal(expectedSource))
 		})
@@ -158,7 +168,7 @@ var _ = Describe("Out New Relic", func() {
 				func() {
 					inputMap := make(FluentBitRecord)
 
-					foundOutput := RemapRecord(inputMap, input, pluginVersion)
+					foundOutput := RemapRecord(inputMap, input, pluginVersion, false)
 
 					Expect(foundOutput["timestamp"]).To(Equal(expected))
 				},
@@ -169,7 +179,7 @@ var _ = Describe("Out New Relic", func() {
 			inputMap := make(FluentBitRecord)
 
 			// We don't handle string types
-			foundOutput := RemapRecord(inputMap, "1234567890", pluginVersion)
+			foundOutput := RemapRecord(inputMap, "1234567890", pluginVersion, false)
 
 			Expect(foundOutput["timestamp"]).To(BeNil())
 		})


### PR DESCRIPTION
In the Kubernetes initiative we are working on reducing the data ingest from the default Kubernetes installation. For logs we are removing unnecessary attributes. The fluentbit output plugin is adding 'plugin' information to the logs, this PR implements a low data mode that omits this plugin information.