### PR TITLE
Fix: adapt unit tests to new retry logic

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Run unit tests
         run: |
           go get -v -u github.com/jstemmer/go-junit-report
-          go test -v ./... 2>&1 | go-junit-report > test-results.xml
+          go test -v ./... 2>&1 | go-junit-report -set-exit-code=1 > test-results.xml
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.19
@@ -90,7 +90,7 @@ jobs:
           platforms: ${{ matrix.platforms }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      
+
       - name: Inspect generated Docker image (${{ matrix.name }})
         run: docker buildx imagetools inspect localhost:5000/fb-output-plugin
 
@@ -98,7 +98,7 @@ jobs:
         run: bash test.sh
 
   docker-windows-ci:
-    name:  CI - Docker image for ${{ matrix.name }} 
+    name:  CI - Docker image for ${{ matrix.name }}
     # Right now, the windows-2019 worker offerred by GitHub is based on ltsc2019/10.0.17763.2183, so it can only compile containers running this specific version and compilation number of the OS.
     # We aim to support (but right now, we can only support LTSC2019 using GitHub actions): https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
     # More info: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#choose_your_windows_server_node_image

--- a/nrclient/nrclient_test.go
+++ b/nrclient/nrclient_test.go
@@ -1,6 +1,8 @@
 package nrclient
 
 import (
+	"net/http"
+
 	"github.com/newrelic/newrelic-fluent-bit-output/config"
 	"github.com/newrelic/newrelic-fluent-bit-output/record"
 	"github.com/onsi/ginkgo"
@@ -8,7 +10,6 @@ import (
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-	"net/http"
 )
 
 var _ = Describe("NR Client", func() {
@@ -69,10 +70,10 @@ var _ = Describe("NR Client", func() {
 		}
 
 		// When
-		statusCode, err := nrClient.Send(nil)
+		shouldRetry, err := nrClient.Send(nil)
 
 		// Then
-		Expect(statusCode).To(Equal(http.StatusAccepted))
+		Expect(shouldRetry).To(BeFalse())
 		Expect(err).To(BeNil())
 		Expect(server.ReceivedRequests()).To(HaveLen(0))
 	})
@@ -86,10 +87,10 @@ var _ = Describe("NR Client", func() {
 
 		// When
 
-		statusCode, err := nrClient.Send([]record.LogRecord{})
+		shouldRetry, err := nrClient.Send([]record.LogRecord{})
 
 		// Then
-		Expect(statusCode).To(Equal(http.StatusAccepted))
+		Expect(shouldRetry).To(BeFalse())
 		Expect(err).To(BeNil())
 		Expect(server.ReceivedRequests()).To(HaveLen(0))
 	})
@@ -112,10 +113,10 @@ var _ = Describe("NR Client", func() {
 		}
 
 		// When
-		statusCode, err := nrClient.Send(logRecords)
+		shouldRetry, err := nrClient.Send(logRecords)
 
 		// Then
-		Expect(statusCode).To(Equal(http.StatusAccepted))
+		Expect(shouldRetry).To(BeFalse())
 		Expect(err).To(BeNil())
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 	})
@@ -138,10 +139,10 @@ var _ = Describe("NR Client", func() {
 		}
 
 		// When
-		statusCode, err := nrClient.Send(logRecords)
+		shouldRetry, err := nrClient.Send(logRecords)
 
 		// Then
-		Expect(statusCode).To(Equal(http.StatusAccepted))
+		Expect(shouldRetry).To(BeFalse())
 		Expect(err).To(BeNil())
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 	})
@@ -164,10 +165,10 @@ var _ = Describe("NR Client", func() {
 		}
 
 		// When
-		statusCode, err := nrClient.Send(logRecords)
+		shouldRetry, err := nrClient.Send(logRecords)
 
 		// Then
-		Expect(statusCode).To(Equal(vortexServerErrorCode))
+		Expect(shouldRetry).To(BeTrue())
 		Expect(err).To(BeNil())
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 	})

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.12.0"
+const VERSION = "1.12.1"


### PR DESCRIPTION
This adapts the unit tests to the logic introduced on #96 