### PR TITLE
Update fluent-bit from 1.8.1 to 1.8.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:1.8.1
+FROM fluent/fluent-bit:1.8.10
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/


### PR DESCRIPTION
A number of new plugins have been introduced. At Skyscanner we intend to use the `fluentbit_metrics` input plugin to gather Fluent Bit's own metrics and remote-write them to New Relic. This plugin was introduced in Fluent Bit 1.8.4. It seems to work fine for me locally and I successfully sent the metrics to New Relic. I don't see any contribution guidelines beyond the code of conduct, is there anything in particular I should do to test this?