### PR TITLE
feat: update fb docker images to v1.8.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:1.8.1
+FROM fluent/fluent-bit:1.8.11
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -63,7 +63,7 @@ RUN go build -buildmode=c-shared -o out_newrelic.dll .
 FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as builder
 
 # The FLUENTBIT_VERSION ARG must be after the FROM instruction
-ARG FLUENTBIT_VERSION=1.8.1
+ARG FLUENTBIT_VERSION=1.8.11
 ARG IMAGE_CREATE_DATE
 ARG IMAGE_SOURCE_REVISION
 

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:1.8.1-debug
+FROM fluent/fluent-bit:1.8.11-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM amazon/aws-for-fluent-bit:2.17.0
+FROM amazon/aws-for-fluent-bit:2.21.5
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.12.1"
+const VERSION = "1.12.2"


### PR DESCRIPTION
Release notes from dependencies:

d99fd2ad38c2f91befbc9f2a4f192504eab1480a, 27524abc47bfc421637e60884bc1fa9d970f5211 fb +debug -> [v1.8.11](https://fluentbit.io/announcements/v1.8.11/)
70a1a948e61fa20eb9621c34d79c99af5f559d4f firelens -> aws/aws-for-fluent-bit [v1.21.5](https://github.com/aws/aws-for-fluent-bit/releases/tag/v2.21.5)
d8c3931091de96e14167fd4025c18072807cbb76 windows ??? 🤷‍♀️ 