### PR TITLE
Improve misleading message that causes lots of confusion for customers

### DIFF
--- a/nrclient/proxy_windows.go
+++ b/nrclient/proxy_windows.go
@@ -8,8 +8,6 @@ import (
 // since Go 1.8, Go can't properly load the System root certificates on windows.
 // For more info, search Golang issues 16736 and 18609
 func systemCertPool() *x509.CertPool {
-	log.Warn("Can't load load the system root certificates. If you have set up the" +
-		" 'caBundleFile' or 'caBundleDir' configuration options, you will need to manually download the New Relic" +
-		" site certificate and store it into your CA bundle dir")
+	log.Info("Please check our documentation if you need to set up a proxy with self-signed certificates: https://github.com/newrelic/newrelic-fluent-bit-output#windows")
 	return x509.NewCertPool()
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.12.2"
+const VERSION = "1.12.3"


### PR DESCRIPTION
Many customers using our plugin under Windows (either with a standalone Fluent Bit installation or by using the Infrastructure Agent) have been confused by this message, originally emitted as a `WARNING`. This was just an informative message, so I've reduced its level to `Info`. Moreover, given that now we have proper documentation around setting up self-signed certificates on Windows in our GitHub readme, I've included a link instead of a longer (and probably confusing) text.