### PR TITLE
fix: check for plugin.type in dot notation before overwrite

### DIFF
--- a/record/record.go
+++ b/record/record.go
@@ -42,7 +42,7 @@ func RemapRecord(inputRecord FluentBitRecord, inputTimestamp interface{}, plugin
 	if !ok {
 		source = "BARE-METAL"
 	}
-	if _, ok = outputRecord["plugin"]; !ok {
+	if !pluginTypeIsSet(outputRecord) {
 		if dataFormatConfig.LowDataMode {
 			outputRecord["plugin.source"] = source + "-fb-" + pluginVersion
 		} else {
@@ -143,4 +143,16 @@ func asGzippedJson(records []LogRecord) (*bytes.Buffer, error) {
 		return nil, err
 	}
 	return buff, nil
+}
+
+// Check if the plugin type is set on the record using an object
+// `{"plugin": {"type": "something"}}` or using dot notation
+// `plugin.type="something"`
+func pluginTypeIsSet(record LogRecord) bool {
+	for _, key := range []string{"plugin", "plugin.type"} {
+		if _, ok := record[key]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -65,6 +65,19 @@ var _ = Describe("Out New Relic", func() {
 			Expect(pluginMap["type"]).To(Equal(expectedType))
 		})
 
+		It("Doesn't rewrite plugin.type [dot notation] if it exits", func() {
+			inputMap := make(FluentBitRecord)
+			var inputTimestamp interface{}
+			inputTimestamp = output.FLBTime{
+				time.Now(),
+			}
+			expectedType := "something"
+			inputMap["plugin.type"] = expectedType
+			foundOutput := RemapRecord(inputMap, inputTimestamp, pluginVersion, config.DataFormatConfig{false})
+			pluginString := foundOutput["plugin.type"].(string)
+			Expect(pluginString).To(Equal(expectedType))
+		})
+
 		It("Doesn't add plugin.type and plugin.version and uses compacted plugin.source format when in low data mode", func() {
 			inputMap := make(FluentBitRecord)
 			var inputTimestamp interface{}

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Out New Relic", func() {
 			Expect(source).To(Equal("BARE-METAL"))
 		})
 
-		It("Doesn't rewrite plugin.type if it exits", func() {
+		It("Doesn't rewrite plugin.type if it exists", func() {
 			inputMap := make(FluentBitRecord)
 			var inputTimestamp interface{}
 			inputTimestamp = output.FLBTime{
@@ -65,7 +65,7 @@ var _ = Describe("Out New Relic", func() {
 			Expect(pluginMap["type"]).To(Equal(expectedType))
 		})
 
-		It("Doesn't rewrite plugin.type [dot notation] if it exits", func() {
+		It("Doesn't rewrite plugin.type [dot notation] if it exists", func() {
 			inputMap := make(FluentBitRecord)
 			var inputTimestamp interface{}
 			inputTimestamp = output.FLBTime{


### PR DESCRIPTION
This PR fixes an issue when plugin.type is present on the log record in dot notation instead of a structured object.

Only thing we do is check if it exists in that format as we did with structured object before.

This will incur in breaking changes for data being forwarder for some clients so... that's the reason of not merging it.