### PR TITLE
Retry sending logs if a timeout error happens

### DIFF
--- a/out_newrelic.go
+++ b/out_newrelic.go
@@ -70,13 +70,13 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 	// output.FLB_ERROR = unrecoverable error, do not try this again.
 	// output.FLB_RETRY = retry to flush later.
 	retry, err := nrClient.Send(buffer)
-	if err != nil {
-		log.WithField("error", err).Error("Non-retryable error received. Retry:false")
-		return output.FLB_ERROR
-	}
 	if retry {
-		log.Debug("Retryable error received. Retry:true")
+		log.Debug("Retryable error received.")
 		return output.FLB_RETRY
+	}
+	if err != nil {
+		log.WithField("error", err).Error("Non-retryable error received. Logs were discarded.")
+		return output.FLB_ERROR
 	}
 	return output.FLB_OK
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.13.0"
+const VERSION = "1.13.1"


### PR DESCRIPTION
# Description
The current logic considered timeout errors as non-retriable. The present PR modifies this logic so that timeout errors will be retried (as long as the user specified the `Retry_Limit` option when configuring the plugin).

# Tests
We tested the new functionality in two ways:
- By manually testing it: we spinned up a local Mockserver and started a Docker image of the plugin pointing to it. We then sent logs by modifying the delay introduced by the Mocksever in the response, and observed how the timeout errors happened and were retried by Fluent Bit (up to `Retry_Limit`).
- By adding a new unit test that deliberately introduces a delay in the response greater than the configured timeout. This results in the method to return `retry=true`, as expected.