### PR TITLE
Upgrades Docker images to be based on Fluent Bit 1.9.9 and Go in Docker images to 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 AS builder
+FROM golang:1.14 AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 
@@ -9,8 +9,6 @@ COPY record/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/record
 COPY utils/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/utils
 
 ENV SOURCE docker
-RUN go get github.com/fluent/fluent-bit-go/output
-RUN go get github.com/sirupsen/logrus
 
 # Not using default value here due to this: https://github.com/docker/buildx/issues/510
 ARG TARGETPLATFORM

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:1.9.4
+FROM fluent/fluent-bit:1.9.9
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=1.9.4
+ARG FLUENTBIT_VERSION=1.9.9
 ARG WINDOWS_VERSION=ltsc2019
 
 #################################################

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -26,7 +26,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.12
+RUN choco install --yes --no-progress golang --version=1.14
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -43,6 +43,9 @@ ENV SOURCE docker
 RUN setx CGO_ENABLED "1"
 RUN setx GOOS "windows"
 RUN setx GOARCH "amd64"
+RUN setx CC "x86_64-w64-mingw32-gcc"
+RUN setx CXX "x86_64-w64-mingw32-g++"
+
 RUN go build -buildmode=c-shared -o out_newrelic.dll .
 
 

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -9,8 +9,6 @@ COPY record/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/record
 COPY utils/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/utils
 
 ENV SOURCE docker
-RUN go get github.com/fluent/fluent-bit-go/output
-RUN go get github.com/sirupsen/logrus
 
 # Not using default value here due to this: https://github.com/docker/buildx/issues/510
 ARG TARGETPLATFORM

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:1.9.4-debug
+FROM fluent/fluent-bit:1.9.9-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,4 +1,4 @@
-FROM golang:1.11 AS builder
+FROM golang:1.14 AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -9,8 +9,6 @@ COPY record/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/record
 COPY utils/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/utils
 
 ENV SOURCE docker
-RUN go get github.com/fluent/fluent-bit-go/output
-RUN go get github.com/sirupsen/logrus
 
 # Not using default value here due to this: https://github.com/docker/buildx/issues/510
 ARG TARGETPLATFORM

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -18,8 +18,8 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-# aws-for-fluent-bit 2.26.0 is based on Fluent Bit 1.9.4
-FROM amazon/aws-for-fluent-bit:2.26.0
+# aws-for-fluent-bit 2.28.3 is based on Fluent Bit 1.9.9: https://github.com/fala-aws/aws-for-fluent-bit/blob/mainline/CHANGELOG.md#2283
+FROM amazon/aws-for-fluent-bit:2.28.3
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,4 +1,4 @@
-FROM golang:1.11 AS builder
+FROM golang:1.14 AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/newrelic-fluent-bit-output
 
-go 1.12
+go 1.14
 
 require (
 	github.com/fluent/fluent-bit-go v0.0.0-20200729034236-b9c0d6a20853

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/fluent/fluent-bit-go v0.0.0-20200729034236-b9c0d6a20853
+github.com/fluent/fluent-bit-go v0.0.0-20200729034236-b9c0d6a20853
 github.com/fluent/fluent-bit-go/output
 # github.com/golang/protobuf v1.2.0
 github.com/golang/protobuf/proto
@@ -8,7 +8,7 @@ github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
 github.com/hpcloud/tail/watch
 github.com/hpcloud/tail/winfile
-# github.com/onsi/ginkgo v1.8.0
+github.com/onsi/ginkgo v1.8.0
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
@@ -27,7 +27,7 @@ github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
-# github.com/onsi/gomega v1.5.0
+github.com/onsi/gomega v1.5.0
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/ghttp
@@ -41,7 +41,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/sirupsen/logrus v1.8.1
+github.com/sirupsen/logrus v1.8.1
 github.com/sirupsen/logrus
 # github.com/ugorji/go/codec v1.1.7
 github.com/ugorji/go/codec

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
-github.com/fluent/fluent-bit-go v0.0.0-20200729034236-b9c0d6a20853
+# github.com/fluent/fluent-bit-go v0.0.0-20200729034236-b9c0d6a20853
+## explicit
 github.com/fluent/fluent-bit-go/output
 # github.com/golang/protobuf v1.2.0
 github.com/golang/protobuf/proto
@@ -8,7 +9,8 @@ github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
 github.com/hpcloud/tail/watch
 github.com/hpcloud/tail/winfile
-github.com/onsi/ginkgo v1.8.0
+# github.com/onsi/ginkgo v1.8.0
+## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
@@ -27,7 +29,8 @@ github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
-github.com/onsi/gomega v1.5.0
+# github.com/onsi/gomega v1.5.0
+## explicit
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/ghttp
@@ -41,7 +44,8 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-github.com/sirupsen/logrus v1.8.1
+# github.com/sirupsen/logrus v1.8.1
+## explicit
 github.com/sirupsen/logrus
 # github.com/ugorji/go/codec v1.1.7
 github.com/ugorji/go/codec

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.14.0"
+const VERSION = "1.14.1"


### PR DESCRIPTION
This PR addresses:
- Upgrades Docker images to use Fluent Bit 1.9.9.
- Upgrades Go to 1.14 in the Docker builder images, so it is in line with [the version that we were using](https://github.com/newrelic/newrelic-fluent-bit-output/blob/master/.github/workflows/merge-to-master.yml#L14-L17) when [building the standalone plugin](https://github.com/newrelic/newrelic-fluent-bit-output/blob/master/.github/workflows/merge-to-master.yml#L36-L49) (which is [used by the Infrastructure Agent](https://github.com/newrelic/infrastructure-agent/blob/e0fc2d4f8faf2405abb25c7fde66150b85213575/build/embed/fluent-bit.mk#L13)).

The upgrade to Go 1.14 was necessary since some `go get` statements were failing when building the Docker images. This made me realise that we were using Go 1.11 in the Docker builder, whereas we were using Go 1.14 when building the standalone plugin. So, I aligned the versions being used in all of them to 1.14.

This does not have an impact to the standalone plugin being used by the Infrastructure Agent (as it is built with the exact same Go version), only for the plugin that gets included in the resulting Docker images, which are tested [here](https://github.com/newrelic/newrelic-fluent-bit-output/blob/master/.github/workflows/pr.yaml#L97-L98).