### PR TITLE
Use Record's timestamp preferably

### DIFF
--- a/record/record.go
+++ b/record/record.go
@@ -81,9 +81,9 @@ func parseValue(value interface{}) interface{} {
 	}
 }
 
-func resolveTimestamp(outputRecord LogRecord, inputTimestamp interface{}) (int64, error) {
-	if val, ok := outputRecord["timestamp"].(int64); ok {
-		return utils.TimeToMillis(val), nil
+func resolveTimestamp(outputRecord LogRecord, inputTimestamp interface{}) (interface{}, error) {
+	if val, ok := outputRecord["timestamp"]; ok {
+		return val, nil
 	}
 
 	switch inputTimestamp.(type) {

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -184,6 +184,14 @@ var _ = Describe("Out New Relic", func() {
 
 			Expect(foundOutput["timestamp"]).To(BeNil())
 		})
+
+		It("Record timestamp has precedence over fluentbit's", func() {
+			inputMap := FluentBitRecord{"timestamp": int64(654321)}
+
+			foundOutput := RemapRecord(inputMap, uint64(1234567890), pluginVersion, config.DataFormatConfig{false})
+
+			Expect(foundOutput["timestamp"]).To(Equal(int64(654321000)))
+		})
 	})
 
 	Describe("Record packaging", func() {

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -186,11 +186,11 @@ var _ = Describe("Out New Relic", func() {
 		})
 
 		It("Record timestamp has precedence over fluentbit's", func() {
-			inputMap := FluentBitRecord{"timestamp": int64(654321)}
+			inputMap := FluentBitRecord{"timestamp": 654321}
 
 			foundOutput := RemapRecord(inputMap, uint64(1234567890), pluginVersion, config.DataFormatConfig{false})
 
-			Expect(foundOutput["timestamp"]).To(Equal(int64(654321000)))
+			Expect(foundOutput["timestamp"]).To(Equal(654321))
 		})
 	})
 

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -185,6 +185,8 @@ var _ = Describe("Out New Relic", func() {
 			Expect(foundOutput["timestamp"]).To(BeNil())
 		})
 
+		// If the record has a timestamp attribute, we use it as-is
+		// Otherwise we use the timestamp provided by fluentbit
 		It("Record timestamp has precedence over fluentbit's", func() {
 			inputMap := FluentBitRecord{"timestamp": 654321}
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.14.1"
+const VERSION = "1.14.2"


### PR DESCRIPTION
If the received record contains a valid `int64` `timestamp` attribute,
   we use this as the `timestamp`.
Otherwise use fluentbit's observed `timestamp`.