### PR TITLE
Adds support to run on Windows Server 2022 (LTSC)

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -207,18 +207,23 @@ jobs:
 
   windows-docker-images:
     name:  ${{ matrix.name }} Docker image generation and publishing
-    # Right now, the windows-2019 worker offerred by GitHub is based on ltsc2019/10.0.17763.2183, so it can only compile containers running this specific version and compilation number of the OS.
-    # We aim to support (but right now, we can only support LTSC2019 using GitHub actions): https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
+    # We aim to support https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
     # More info: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#choose_your_windows_server_node_image
     # Tag reference: https://hub.docker.com/_/microsoft-windows-servercore
     # Compatibility matrix: https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
-    runs-on: windows-2019
     strategy:
       matrix:
         include:
           - name: Windows Server 2019 (LTSC)
             windowsImageTag: ltsc2019-amd64
             imageTagSuffix: windows-ltsc-2019
+            runsOn: windows-2019
+          - name: Windows Server 2022 (LTSC)
+            windowsImageTag: ltsc2022-amd64
+            imageTagSuffix: windows-ltsc-2022
+            runsOn: windows-2022
+
+    runs-on: ${{ matrix.runsOn }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,18 +99,23 @@ jobs:
 
   docker-windows-ci:
     name:  CI - Docker image for ${{ matrix.name }}
-    # Right now, the windows-2019 worker offerred by GitHub is based on ltsc2019/10.0.17763.2183, so it can only compile containers running this specific version and compilation number of the OS.
-    # We aim to support (but right now, we can only support LTSC2019 using GitHub actions): https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
+    # We aim to support https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
     # More info: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#choose_your_windows_server_node_image
     # Tag reference: https://hub.docker.com/_/microsoft-windows-servercore
     # Compatibility matrix: https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
-    runs-on: windows-2019
     strategy:
       matrix:
         include:
           - name: Windows Server 2019 (LTSC)
             windowsImageTag: ltsc2019-amd64
             imageTagSuffix: windows-ltsc-2019
+            runsOn: windows-2019
+          - name: Windows Server 2022 (LTSC)
+            windowsImageTag: ltsc2022-amd64
+            imageTagSuffix: windows-ltsc-2022
+            runsOn: windows-2022
+
+    runs-on: ${{ matrix.runsOn }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
In order for a windows node to run a windows container image, both need to match the exact version and build number.
Currently we only support [Windows Server 2019 (LTSC)](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging/values.yaml#L176).

This PR adds building an image for Windows 2022 (LTSC) allowing our plugin to run on Windows 2022 (LTSC) hosts. 

References
- https://kubernetes.io/docs/concepts/windows/intro/#windows-os-version-support