### PR TITLE
Inform the http status code for retriable requests

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -11,10 +11,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go 1.14
+      - name: Set up Go ^1.14
         uses: actions/setup-go@v2
         with:
           go-version: ^1.14
+
+      - name: Check go version
+        run: go version
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go ^1.14
+      - name: Set up Go ^1.20
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.14
+          go-version: ^1.20
 
       - name: Check go version
         run: go version

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   cd:
     name: Continuous Delivery pipeline
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Set up Go 1.14

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go ^1.14
+      - name: Set up Go ^1.20
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.14
+          go-version: ^1.20
         id: go
 
       - name: Check go version

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   unit-tests:
     name: CI - Tests and Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Set up Go 1.14
@@ -33,7 +33,7 @@ jobs:
 
   docker-ci:
     name: CI - Docker image build (${{ matrix.name }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     services:
       registry:
         image: registry:2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
           go test -v ./... 2>&1 | go-junit-report -set-exit-code=1 > test-results.xml
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.19
+        uses: EnricoMi/publish-unit-test-result-action@v2.6.2
         if: always()
         with:
           files: test-results.xml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,11 +8,14 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go 1.14
+      - name: Set up Go ^1.14
         uses: actions/setup-go@v2
         with:
           go-version: ^1.14
         id: go
+
+      - name: Check go version
+        run: go version
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -11,7 +11,7 @@ on: [push, workflow_dispatch]
 jobs:
   repolint:
     name: Run Repolinter
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Test Default Branch
         id: default-branch

--- a/nrclient/nrclient.go
+++ b/nrclient/nrclient.go
@@ -62,10 +62,11 @@ func (nrClient *NRClient) Send(logRecords []record.LogRecord) (retry bool, err e
 		}
 
 		// ...unless we receive an explicit non-2XX HTTP status code from the server that tells us otherwise
-		if statusCode/100 != 2 && isStatusCodeRetryable(statusCode) {
-			return true, fmt.Errorf("received non-2XX HTTP status code: %d", statusCode)
+		if statusCode/100 != 2 {
+			return isStatusCodeRetryable(statusCode), fmt.Errorf("received non-2XX HTTP status code: %d", statusCode)
 		}
 	}
+
 	return false, nil
 }
 

--- a/nrclient/nrclient.go
+++ b/nrclient/nrclient.go
@@ -63,7 +63,7 @@ func (nrClient *NRClient) Send(logRecords []record.LogRecord) (retry bool, err e
 
 		// ...unless we receive an explicit non-2XX HTTP status code from the server that tells us otherwise
 		if statusCode/100 != 2 && isStatusCodeRetryable(statusCode) {
-			return true, nil
+			return true, fmt.Errorf("received non-2XX HTTP status code: %d", statusCode)
 		}
 	}
 	return false, nil

--- a/nrclient/nrclient_test.go
+++ b/nrclient/nrclient_test.go
@@ -1,6 +1,7 @@
 package nrclient
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -175,7 +176,7 @@ var _ = Describe("NR Client", func() {
 
 		// Then
 		Expect(shouldRetry).To(BeTrue())
-		Expect(err).To(BeNil())
+    Expect(err).To(MatchError(fmt.Sprintf("received non-2XX HTTP status code: %d", httpRetryableErrorCode)))
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 	})
 

--- a/nrclient/nrclient_test.go
+++ b/nrclient/nrclient_test.go
@@ -202,7 +202,7 @@ var _ = Describe("NR Client", func() {
 
 		// Then
 		Expect(shouldRetry).To(BeFalse())
-		Expect(err).To(BeNil())
+    Expect(err).To(MatchError(fmt.Sprintf("received non-2XX HTTP status code: %d", httpNonRetryableErrorCode)))
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 	})
 

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -5,11 +5,12 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"github.com/newrelic/newrelic-fluent-bit-output/config"
 	"io"
 	"math/rand"
 	"os"
 	"time"
+
+	"github.com/newrelic/newrelic-fluent-bit-output/config"
 
 	"github.com/fluent/fluent-bit-go/output"
 	"github.com/onsi/ginkgo"
@@ -320,10 +321,10 @@ var _ = Describe("Out New Relic", func() {
 			// Then
 			Expect(err).To(BeNil())
 			Expect(packagedRecords).To(Not(BeNil()))
-			// The 20 records are compressed into 8 byte buffers, as overall they exceed 1MB. Note that this is
+			// The 20 records are compressed into 12 byte buffers, as overall they exceed 1MB. Note that this is
 			// a deterministic result (unless the gzip implementation changes), since we're always using the same
 			// seed when generating the random messages, which will lead to the same messages always being sent.
-			Expect(packagedRecords).To(HaveLen(8))
+			Expect(packagedRecords).To(HaveLen(12))
 
 			// Count that we end up having 20 uncompressed records, with all the recordIds
 			type Record struct {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.14.2"
+const VERSION = "1.15.0"


### PR DESCRIPTION
Right now if a retriable error happens we're not able to see which HTTP status code was.
This adds the status code as an error on the nrclient and will be logged by out_newrelic.