### PR TITLE
feat: [NR-77107] - Upgrade FluentBit images to 1.9.10/2.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:1.9.9
+FROM fluent/fluent-bit:2.0.8
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=1.9.9
+ARG FLUENTBIT_VERSION=2.0.8
 ARG WINDOWS_VERSION=ltsc2019
 
 #################################################

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -16,7 +16,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:1.9.9-debug
+FROM fluent/fluent-bit:2.0.8-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -17,7 +17,7 @@ RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
 # aws-for-fluent-bit 2.28.3 is based on Fluent Bit 1.9.9: https://github.com/fala-aws/aws-for-fluent-bit/blob/mainline/CHANGELOG.md#2283
-FROM amazon/aws-for-fluent-bit:2.28.3
+FROM amazon/aws-for-fluent-bit:2.31.8
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.14.2"
+const VERSION = "1.15.0"


### PR DESCRIPTION
These changes in the FluentBit image remove the vulnerability [CVE-2021-46848](https://security-tracker.debian.org/tracker/CVE-2021-46848)

### Work done
- Upgraded FluentBit to v2.0.8 for Linux and Windows
- Upgraded FluentBit to v1.9.10 for AWS for FluentBit image
### Ticket
- https://issues.newrelic.com/browse/NR-77107