### PR TITLE
feat: Upgraded FluentBit version to 2.0.8/1.9.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:1.9.9
+FROM fluent/fluent-bit:2.0.8
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=1.9.9
+ARG FLUENTBIT_VERSION=2.0.8
 ARG WINDOWS_VERSION=ltsc2019
 
 #################################################
@@ -123,11 +123,17 @@ RUN Start-Process /local/vc_redist.x64.exe -ArgumentList '/install', '/quiet', '
     Copy-Item -Path /Windows/System32/vccorlib140.dll -Destination /fluent-bit/bin/; `
     Copy-Item -Path /Windows/System32/vcruntime140.dll -Destination /fluent-bit/bin/;
 
+# Install Chocolatey and OpenSSL: https://github.com/StefanScherer/dockerfiles-windows/blob/main/openssl/Dockerfile
+ENV chocolateyUseWindowsCompression false
+RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); `
+    choco feature disable --name showDownloadProgress ; `
+    choco install -y openssl;
+
 # Build Fluent Bit from source - context must be the root of the Git repo
 WORKDIR /src/build
 # COPY . /src/
 
-RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=Release ../; `
+RUN cmake -G "'Visual Studio 16 2019'" -DOPENSSL_ROOT_DIR='C:\Program Files\OpenSSL-Win64' -DCMAKE_BUILD_TYPE=Release ../;`
     cmake --build . --config Release;
 
 # Set up config files and binaries in single /fluent-bit hierarchy for easy copy in later stage
@@ -154,22 +160,22 @@ ARG IMAGE_SOURCE_REVISION
 # Metadata as defined in OCI image spec annotations
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL org.opencontainers.image.title="Fluent Bit" `
-      org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
-      org.opencontainers.image.created=$IMAGE_CREATE_DATE `
-      org.opencontainers.image.version=$FLUENTBIT_VERSION `
-      org.opencontainers.image.authors="Eduardo Silva <eduardo@calyptia.com>" `
-      org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
-      org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
-      org.opencontainers.image.vendor="Fluent Organization" `
-      org.opencontainers.image.licenses="Apache-2.0" `
-      org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
-      org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
+    org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
+    org.opencontainers.image.created=$IMAGE_CREATE_DATE `
+    org.opencontainers.image.version=$FLUENTBIT_VERSION `
+    org.opencontainers.image.authors="Eduardo Silva <eduardo@calyptia.com>" `
+    org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
+    org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
+    org.opencontainers.image.vendor="Fluent Organization" `
+    org.opencontainers.image.licenses="Apache-2.0" `
+    org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
+    org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
 
 COPY --from=builder /fluent-bit /fluent-bit
 
 RUN setx /M PATH "%PATH%;C:\fluent-bit\bin"
 
-ENTRYPOINT [ "C:\fluent-bit\bin\fluent-bit.exe" ]
+ENTRYPOINT [ "fluent-bit.exe" ]
 
 COPY --from=nrBuilder /build/out_newrelic.dll /fluent-bit/bin/out_newrelic.dll
 

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -16,7 +16,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:1.9.9-debug
+FROM fluent/fluent-bit:2.0.8-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -16,8 +16,8 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-# aws-for-fluent-bit 2.28.3 is based on Fluent Bit 1.9.9: https://github.com/fala-aws/aws-for-fluent-bit/blob/mainline/CHANGELOG.md#2283
-FROM amazon/aws-for-fluent-bit:2.28.3
+# aws-for-fluent-bit 2.31.8 is based on Fluent Bit 1.9.10: https://github.com/fala-aws/aws-for-fluent-bit/blob/mainline/CHANGELOG.md#2318
+FROM amazon/aws-for-fluent-bit:2.31.8
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.15.0"
+const VERSION = "1.16.0"


### PR DESCRIPTION
These changes in the FluentBit image remove the vulnerability [CVE-2021-46848](https://security-tracker.debian.org/tracker/CVE-2021-46848)


- Bumped FluentBit Windows and Linux to v2.0.8
- Bumped FluentBit for AWS to v2.31.8 (based on FluentBit 1.9.10)
- Updated Dockerfile.windows to support FluentBit 2.0.8