### PR TITLE
Upgrade golang to 1.20.5

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -218,11 +218,11 @@ jobs:
       matrix:
         include:
           - name: Windows Server 2019 (LTSC)
-            windowsImageTag: ltsc2019
+            windowsImageTag: ltsc2019-amd64
             imageTagSuffix: windows-ltsc-2019
             runsOn: windows-2019
           - name: Windows Server 2022 (LTSC)
-            windowsImageTag: ltsc2022
+            windowsImageTag: ltsc2022-amd64
             imageTagSuffix: windows-ltsc-2022
             runsOn: windows-2022
 

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go ^1.20
+      - name: Set up Go ^1.20.5
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.20
+          go-version: ^1.20.5
 
       - name: Check go version
         run: go version

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -218,11 +218,11 @@ jobs:
       matrix:
         include:
           - name: Windows Server 2019 (LTSC)
-            windowsImageTag: ltsc2019-amd64
+            windowsImageTag: ltsc2019
             imageTagSuffix: windows-ltsc-2019
             runsOn: windows-2019
           - name: Windows Server 2022 (LTSC)
-            windowsImageTag: ltsc2022-amd64
+            windowsImageTag: ltsc2022
             imageTagSuffix: windows-ltsc-2022
             runsOn: windows-2022
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go ^1.20
+      - name: Set up Go ^1.20.5
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.20
+          go-version: ^1.20.5
         id: go
 
       - name: Check go version
@@ -110,11 +110,11 @@ jobs:
       matrix:
         include:
           - name: Windows Server 2019 (LTSC)
-            windowsImageTag: ltsc2019-amd64
+            windowsImageTag: ltsc2019
             imageTagSuffix: windows-ltsc-2019
             runsOn: windows-2019
           - name: Windows Server 2022 (LTSC)
-            windowsImageTag: ltsc2022-amd64
+            windowsImageTag: ltsc2022
             imageTagSuffix: windows-ltsc-2022
             runsOn: windows-2022
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -110,11 +110,11 @@ jobs:
       matrix:
         include:
           - name: Windows Server 2019 (LTSC)
-            windowsImageTag: ltsc2019
+            windowsImageTag: ltsc2019-amd64
             imageTagSuffix: windows-ltsc-2019
             runsOn: windows-2019
           - name: Windows Server 2022 (LTSC)
-            windowsImageTag: ltsc2022
+            windowsImageTag: ltsc2022-amd64
             imageTagSuffix: windows-ltsc-2022
             runsOn: windows-2022
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS builder
+FROM golang:1.20.5 AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -6,11 +6,14 @@ ARG WINDOWS_VERSION=ltsc2019
 #################################################
 # Build New Relic Fluent Bit Output Plugin
 #################################################
-FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-$WINDOWS_VERSION as nrBuilder
+
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION  AS nrBuilder
 
 WORKDIR /build
 
 USER ContainerAdministrator
+
+ENV chocolateyVersion 1.4.0
 
 # Install Chocolatey
 RUN powershell.exe Invoke-WebRequest `
@@ -25,7 +28,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.20.5
+RUN choco install --yes --no-progress golang --version=1.14
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"
@@ -56,9 +59,12 @@ RUN go build -buildmode=c-shared -o out_newrelic.dll .
 # provide a Dockerfile.windows (https://github.com/fluent/fluent-bit/blob/master/dockerfiles/Dockerfile.windows)
 # which we mostly reuse below to build our own image containing Fluent Bit for Windows + New Relic Fluent Bit plugin
 
-FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-$WINDOWS_VERSION as builder
+# Builder Image - Windows Server Core (copied from Fluent Bit's official Dockerfile.windows file)
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as builder
 
 ARG FLUENTBIT_VERSION
+
+ENV chocolateyVersion 1.4.0
 
 # Install Chocolatey
 RUN powershell.exe Invoke-WebRequest `

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -28,7 +28,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.14
+RUN choco install --yes --no-progress golang --version=1.20.5
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"
@@ -64,6 +64,9 @@ FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as builder
 
 ARG FLUENTBIT_VERSION
 
+# This line was added because chocolatey version 2.0 was released and it depends on .NET 4.8
+# We can update this with the approach that fluent-bit takes but at the moment of doing this change
+# the fluent-bit image is not updated (and not working anymore)
 ENV chocolateyVersion 1.4.0
 
 # Install Chocolatey

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -57,8 +57,7 @@ RUN go build -buildmode=c-shared -o out_newrelic.dll .
 # provide a Dockerfile.windows (https://github.com/fluent/fluent-bit/blob/master/dockerfiles/Dockerfile.windows)
 # which we mostly reuse below to build our own image containing Fluent Bit for Windows + New Relic Fluent Bit plugin
 
-# Builder Image - Windows Server Core (copied from Fluent Bit's official Dockerfile.windows file)
-FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as builder
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-$WINDOWS_VERSION as builder
 
 ARG FLUENTBIT_VERSION
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -6,8 +6,7 @@ ARG WINDOWS_VERSION=ltsc2019
 #################################################
 # Build New Relic Fluent Bit Output Plugin
 #################################################
-
-FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION  AS nrBuilder
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-$WINDOWS_VERSION as nrBuilder
 
 WORKDIR /build
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -26,7 +26,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.14
+RUN choco install --yes --no-progress golang --version=1.20.5
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS builder
+FROM golang:1.20.5 AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS builder
+FROM golang:1.20.5 AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.16.0"
+const VERSION = "1.16.1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.16.1"
+const VERSION = "1.17.0"


### PR DESCRIPTION
golang < 1.20.5 contains some vulnerability problems, so this upgrade the golang to 1.20.5 (the latest golang version)