### PR TITLE
Rollback golang image used by docker firelens image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5 AS builder
+FROM golang:1.14 AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -28,7 +28,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.20.5
+RUN choco install --yes --no-progress golang --version=1.14
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"
@@ -107,18 +107,18 @@ ADD https://aka.ms/vs/16/release/vs_buildtools.exe /local/vs_buildtools.exe
 ADD https://aka.ms/vs/16/release/channel /local/VisualStudio.chman
 
 RUN Start-Process /local/vs_buildtools.exe `
-    -ArgumentList '--quiet ', '--wait ', '--norestart ', '--nocache', `
-    '--installPath C:\BuildTools', `
-    '--channelUri C:\local\VisualStudio.chman', `
-    '--installChannelUri C:\local\VisualStudio.chman', `
-    '--add Microsoft.VisualStudio.Workload.VCTools', `
-    '--includeRecommended'  -NoNewWindow -Wait;
+  -ArgumentList '--quiet ', '--wait ', '--norestart ', '--nocache', `
+  '--installPath C:\BuildTools', `
+  '--channelUri C:\local\VisualStudio.chman', `
+  '--installChannelUri C:\local\VisualStudio.chman', `
+  '--add Microsoft.VisualStudio.Workload.VCTools', `
+  '--includeRecommended'  -NoNewWindow -Wait;
 
 ADD https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip /local/win_flex_bison.zip
 
 RUN Expand-Archive /local/win_flex_bison.zip -Destination /WinFlexBison; `
-    Copy-Item -Path /WinFlexBison/win_bison.exe /WinFlexBison/bison.exe; `
-    Copy-Item -Path /WinFlexBison/win_flex.exe /WinFlexBison/flex.exe;
+  Copy-Item -Path /WinFlexBison/win_bison.exe /WinFlexBison/bison.exe; `
+  Copy-Item -Path /WinFlexBison/win_flex.exe /WinFlexBison/flex.exe;
 
 # Technique from https://github.com/StefanScherer/dockerfiles-windows/blob/master/mongo/3.6/Dockerfile
 WORKDIR /local
@@ -126,35 +126,35 @@ ADD https://aka.ms/vs/15/release/vc_redist.x64.exe /local/vc_redist.x64.exe
 
 WORKDIR /fluent-bit/bin/
 RUN Start-Process /local/vc_redist.x64.exe -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
-    Copy-Item -Path /Windows/System32/msvcp140.dll -Destination /fluent-bit/bin/; `
-    Copy-Item -Path /Windows/System32/vccorlib140.dll -Destination /fluent-bit/bin/; `
-    Copy-Item -Path /Windows/System32/vcruntime140.dll -Destination /fluent-bit/bin/;
+  Copy-Item -Path /Windows/System32/msvcp140.dll -Destination /fluent-bit/bin/; `
+  Copy-Item -Path /Windows/System32/vccorlib140.dll -Destination /fluent-bit/bin/; `
+  Copy-Item -Path /Windows/System32/vcruntime140.dll -Destination /fluent-bit/bin/;
 
 # Install Chocolatey and OpenSSL: https://github.com/StefanScherer/dockerfiles-windows/blob/main/openssl/Dockerfile
 ENV chocolateyUseWindowsCompression false
 RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); `
-    choco feature disable --name showDownloadProgress ; `
-    choco install -y openssl;
+  choco feature disable --name showDownloadProgress ; `
+  choco install -y openssl;
 
 # Build Fluent Bit from source - context must be the root of the Git repo
 WORKDIR /src/build
 # COPY . /src/
 
 RUN cmake -G "'Visual Studio 16 2019'" -DOPENSSL_ROOT_DIR='C:\Program Files\OpenSSL-Win64' -DCMAKE_BUILD_TYPE=Release ../;`
-    cmake --build . --config Release;
+  cmake --build . --config Release;
 
 # Set up config files and binaries in single /fluent-bit hierarchy for easy copy in later stage
 RUN New-Item -Path  /fluent-bit/etc/ -ItemType "directory"; `
-    Copy-Item -Path /src/conf/fluent-bit-win32.conf /fluent-bit/etc/fluent-bit.conf; `
-    Copy-Item -Path /src/conf/parsers.conf /fluent-bit/etc/; `
-    Copy-Item -Path /src/conf/parsers_ambassador.conf /fluent-bit/etc/; `
-    Copy-Item -Path /src/conf/parsers_java.conf /fluent-bit/etc/; `
-    Copy-Item -Path /src/conf/parsers_extra.conf /fluent-bit/etc/; `
-    Copy-Item -Path /src/conf/parsers_openstack.conf /fluent-bit/etc/; `
-    Copy-Item -Path /src/conf/parsers_cinder.conf /fluent-bit/etc/; `
-    Copy-Item -Path /src/conf/plugins.conf /fluent-bit/etc/; `
-    Copy-Item -Path /src/build/bin/Release/fluent-bit.exe /fluent-bit/bin/; `
-    Copy-Item -Path /src/build/bin/Release/fluent-bit.dll /fluent-bit/bin/;
+  Copy-Item -Path /src/conf/fluent-bit-win32.conf /fluent-bit/etc/fluent-bit.conf; `
+  Copy-Item -Path /src/conf/parsers.conf /fluent-bit/etc/; `
+  Copy-Item -Path /src/conf/parsers_ambassador.conf /fluent-bit/etc/; `
+  Copy-Item -Path /src/conf/parsers_java.conf /fluent-bit/etc/; `
+  Copy-Item -Path /src/conf/parsers_extra.conf /fluent-bit/etc/; `
+  Copy-Item -Path /src/conf/parsers_openstack.conf /fluent-bit/etc/; `
+  Copy-Item -Path /src/conf/parsers_cinder.conf /fluent-bit/etc/; `
+  Copy-Item -Path /src/conf/plugins.conf /fluent-bit/etc/; `
+  Copy-Item -Path /src/build/bin/Release/fluent-bit.exe /fluent-bit/bin/; `
+  Copy-Item -Path /src/build/bin/Release/fluent-bit.dll /fluent-bit/bin/;
 #
 # Runtime Image - Windows Server Core
 #
@@ -167,16 +167,16 @@ ARG IMAGE_SOURCE_REVISION
 # Metadata as defined in OCI image spec annotations
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL org.opencontainers.image.title="Fluent Bit" `
-    org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
-    org.opencontainers.image.created=$IMAGE_CREATE_DATE `
-    org.opencontainers.image.version=$FLUENTBIT_VERSION `
-    org.opencontainers.image.authors="Eduardo Silva <eduardo@calyptia.com>" `
-    org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
-    org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
-    org.opencontainers.image.vendor="Fluent Organization" `
-    org.opencontainers.image.licenses="Apache-2.0" `
-    org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
-    org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
+  org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
+  org.opencontainers.image.created=$IMAGE_CREATE_DATE `
+  org.opencontainers.image.version=$FLUENTBIT_VERSION `
+  org.opencontainers.image.authors="Eduardo Silva <eduardo@calyptia.com>" `
+  org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
+  org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
+  org.opencontainers.image.vendor="Fluent Organization" `
+  org.opencontainers.image.licenses="Apache-2.0" `
+  org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
+  org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
 
 COPY --from=builder /fluent-bit /fluent-bit
 

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,4 +1,4 @@
-FROM golang:1.20.5 AS builder
+FROM golang:1.14 AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,4 +1,4 @@
-FROM golang:1.20.5 AS builder
+FROM golang:1.14 AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.17.0"
+const VERSION = "1.17.1"


### PR DESCRIPTION
By #133 looks like the previous change break ECR/ECS integrations that uses the Firelens image. Rolling back that change while investigate.