### PR TITLE
Upgrade golang in docker images to 1.20.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS builder
+FROM golang:1.20.5-buster AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -28,7 +28,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.14
+RUN choco install --yes --no-progress golang --version=1.20.5
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS builder
+FROM golang:1.20.5-buster AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS builder
+FROM golang:1.20.5-buster AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.17.2"
+const VERSION = "1.17.3"


### PR DESCRIPTION
golang 1.14 have many vulnerabilities reported so this will upgrade docker images to latest version.


Previous release trying this used golang:1.20.5 which break all the docker images, now we're tying to golang:1.20.5-buster to avoid problems with glibc version included in fluent-bit image.