### PR TITLE
feat: bump Fluent Bit version to 2.2.0. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:2.0.8
+FROM fluent/fluent-bit:2.2.0
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=2.0.8
+ARG FLUENTBIT_VERSION=2.2.0
 ARG WINDOWS_VERSION=ltsc2019
 
 #################################################

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -17,7 +17,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:2.0.8-debug
+FROM fluent/fluent-bit:2.2.0-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -177,6 +177,32 @@ var _ = Describe("Out New Relic", func() {
 			)
 		}
 
+		It("extracts FLBTime timestamp from Fluent Bit Event nested array", func() {
+			inputMap := make(FluentBitRecord)
+
+			timestamp := []interface{}{
+				output.FLBTime{time.Unix(1234567890, 123456789)},
+				"Other metadata",
+			}
+
+			foundOutput := RemapRecord(inputMap, timestamp, pluginVersion, config.DataFormatConfig{false})
+
+			Expect(foundOutput["timestamp"]).To(Equal(int64(1234567890123)))
+		})
+
+		It("extracts UInt64 timestamp from Fluent Bit Event nested array", func() {
+			inputMap := make(FluentBitRecord)
+
+			timestamp := []interface{}{
+				uint64(1234567890),
+				"Other metadata",
+			}
+
+			foundOutput := RemapRecord(inputMap, timestamp, pluginVersion, config.DataFormatConfig{false})
+
+			Expect(foundOutput["timestamp"]).To(Equal(int64(1234567890000)))
+		})
+
 		It("ignores timestamps of unhandled types", func() {
 			inputMap := make(FluentBitRecord)
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.18.0"
+const VERSION = "1.19.0"


### PR DESCRIPTION
## Summary
* Upgraded Fluent Bit version to 2.2.0. 
* Fluent Bit version for FireLens remains without changes
* Updated Output plugin to support the extraction of timestamp from Fluent Bit Event nested array according to the new format introduced in v2.1.0
* Added unit tests for timestamps in Event nested array
* Upgraded Logging Output plugin version to 1.19.0