### PR TITLE
Pin Go to 1.20.12 due to https://github.com/golang/go/issues/62130

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go ^1.20.5
-        uses: actions/setup-go@v2
+      # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
+      - name: Set up Go 1.20.12
+        uses: actions/setup-go@v4
         with:
-          go-version: ^1.20.5
+          go-version: '1.20.12'
 
       - name: Check go version
         run: go version

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-      - name: Set up Go 1.20.12
+      - name: Set up Go 1.20.7
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.12'
+          go-version: '1.20.7'
 
       - name: Check go version
         run: go version

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-      - name: Set up Go 1.20.12
+      - name: Set up Go 1.20.7
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.12'
+          go-version: '1.20.7'
         id: go
 
       - name: Check go version

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go ^1.20.5
-        uses: actions/setup-go@v2
+      # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
+      - name: Set up Go 1.20.12
+        uses: actions/setup-go@v4
         with:
-          go-version: ^1.20.5
+          go-version: '1.20.12'
         id: go
 
       - name: Check go version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.20.5-buster AS builder
+# We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
+FROM golang:1.20.12-buster AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.12-bookworm AS builder
+FROM golang:1.20.12-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.12-buster AS builder
+FROM golang:1.20.12-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.12-bullseye AS builder
+FROM golang:1.20.7-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -28,7 +28,8 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.20.5
+# We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
+RUN choco install --yes --no-progress golang --version=1.20.12
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -29,7 +29,8 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-RUN choco install --yes --no-progress golang --version=1.20.12
+# The last 1.20.X version in chocolatey is 1.20.7
+RUN choco install --yes --no-progress golang --version=1.20.7
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,4 +1,5 @@
-FROM golang:1.20.5-buster AS builder
+# We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
+FROM golang:1.20.12-buster AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.12-bookworm AS builder
+FROM golang:1.20.12-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.12-buster AS builder
+FROM golang:1.20.12-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.12-bullseye AS builder
+FROM golang:1.20.7-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,4 +1,5 @@
-FROM golang:1.20.5-buster AS builder
+# We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
+FROM golang:1.20.12-buster AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.12-bookworm AS builder
+FROM golang:1.20.12-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.12-buster AS builder
+FROM golang:1.20.12-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.12-bullseye AS builder
+FROM golang:1.20.7-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/newrelic/newrelic-fluent-bit-output
 
+// We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
 go 1.20
 
 require (

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.19.0"
+const VERSION = "1.19.1"


### PR DESCRIPTION
# Description
Go 1.21 introduced a bug that causes Fluent Bit to crash when using our plugin. This was reported [here](https://github.com/golang/go/issues/62130#issuecomment-1687335898) as well.

We had inconsistent Go versioning in the plugins we publish:
- The Go version used to compile our "standalone" plugin *.so files was `^1.20.5`, meaning that any version past that one could be used to compile them. In our 1.18.0 plugin, Go `1.21.4` was actually used. This is what "allowed" us to detect the issue. To avoid this happening again, we will pin the version to ~~1.20.12~~ `1.20.7` strictly.
- The Go version used to compile our plugin in the Docker images was actually `1.20.5` (strict), as we are using the official golang buster images. This is what prevented the problem from happening in the Docker images.

For consistency, I've set version `1.20.7` everywhere. There was no `buster` Docker image for `1.20.7`, so I had to upgrade to `bullseye`.

**NOTE:** despite `1.20.12` being the latest `1.20.X` version not affected to this issue, I finally chose to upgrade to `1.20.7` as there was no `1.20.12` Golang package in Chocolatey. This prevented the Windows Docker image from being built. I preferred to use a consistent versioning across all the supported platforms.
