### PR TITLE
feat: generate debug image for linux/arm64 platform

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -108,8 +108,7 @@ jobs:
           tags: |
             ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }}
           builder: ${{ steps.buildx.outputs.name }}
-          # Fluent Bit debug image only available for amd64 architecture
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,8 +51,7 @@ jobs:
             platforms: linux/amd64, linux/arm64, linux/arm/v7
           - name: debug-image
             dockerfile: Dockerfile_debug
-            # Fluent Bit debug image only available for amd64 architecture
-            platforms: linux/amd64
+            platforms: linux/amd64, linux/arm64
           - name: firelens-image
             dockerfile: Dockerfile_firelens
             # Firelens image only available for amd64 and arm64 architectures

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -143,8 +143,8 @@ RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/insta
 WORKDIR /src/build
 # COPY . /src/
 
-RUN cmake -G "'Visual Studio 16 2019'" -DOPENSSL_ROOT_DIR='C:\Program Files\OpenSSL-Win64' -DCMAKE_BUILD_TYPE=Release ../;`
-  cmake --build . --config Release;
+RUN cmake -G "'Visual Studio 16 2019'" -DOPENSSL_ROOT_DIR='C:\Program Files\OpenSSL-Win64\lib\VC\x64\MT' -DOPENSSL_INCLUDE_DIR='C:\Program Files\OpenSSL-Win64\include' -DCMAKE_BUILD_TYPE=Release ../;`
+    cmake --build . --config Release;
 
 # Set up config files and binaries in single /fluent-bit hierarchy for easy copy in later stage
 RUN New-Item -Path  /fluent-bit/etc/ -ItemType "directory"; `


### PR DESCRIPTION
## Summary  
* Updated GitHub actions to generate debug image for `linux/arm64` platform.
* Changes in `Dockerfile.windows` according to the last updated in the [official repo](https://github.com/fluent/fluent-bit/pull/8463/files)