### PR TITLE
Bump fluent bit base image to 2.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:2.2.0
+FROM fluent/fluent-bit:2.2.2
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=2.2.0
+ARG FLUENTBIT_VERSION=2.2.2
 ARG WINDOWS_VERSION=ltsc2019
 
 #################################################

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:2.2.0-debug
+FROM fluent/fluent-bit:2.2.2-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "1.19.1"
+const VERSION = "1.19.2"


### PR DESCRIPTION
This fixes the following vulnerabilities added by libpq5

**HIGH**
[CVE-2023-39417](https://avd.aquasec.com/nvd/cve-2023-39417): postgresql: extension script `@substitutions@` within quoting allow SQL injection
[CVE-2023-5869](https://avd.aquasec.com/nvd/cve-2023-5869): postgresql: Buffer overrun from integer overflow in array modification

**MEDIUM**
[CVE-2023-5868](https://avd.aquasec.com/nvd/cve-2023-5868): postgresql: Memory disclosure in aggregate function calls
[CVE-2023-5870](https://avd.aquasec.com/nvd/cve-2023-5870): postgresql: Role pg_signal_backend can signal certain superuser processes. 