### PR TITLE
ECR Replication rule request

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -132,6 +132,11 @@ jobs:
           ECR_REGISTRY: 533243300146.dkr.ecr.us-east-2.amazonaws.com
           ECR_REPOSITORY: newrelic/logging-firelens-fluentbit
           IMAGE_TAG: ${{ env.VERSION }}
+          REQUEST: > 
+            Please add ECR replication for this repo to the following regions: af-south-1, ca-west-1, eu-central-2, eu-south-1, eu-south-2, me-central-1, me-south-1
+            We have opened a support Case #00167375 on  Nov 28, 2023 with no action so far, so trying to get an engineer's attention that has access to modifying 
+            the ECR replication rules.
+
         with:
           context: ./
           file: ./Dockerfile_firelens


### PR DESCRIPTION
**Context**

There are several AWS supported regions where the AWS FireLens plugin for log forwarding
 is not available, as stated by this [official NewRelic Document](https://docs.newrelic.com/docs/logs/forward-logs/aws-firelens-plugin-log-forwarding/).

**Request**

Assuming NewRelic uses ECR replication rules; please add the following AWS regions to your ECR Replication Rule:

af-south-1, ca-west-1, eu-central-2, eu-south-1, eu-south-2, me-central-1, me-south-1.

I was not able to find infrastructure as code for the ECR repo via terraform or cloudFormation, but if I'm pointed to the right repo and it's public or I get temporary access to the private repo, I would be happy to open a PR implementing the desired changes. 

Note that this PR is not intended to be merged but rather as a mean to get NewRelic's FireLens team's attention. 

____
Request via NewRelic support channel

NewRelic logging-firelens-fluentbit ECR image replication request [STATUS: CLOSED]
Latest Reply: Nov 28, 2023 1:35pm Opened: Nov 9, 2023 11:13am
Case #00167375
