### PR TITLE
Trigger Firelens image publishing in new regions

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.0"
+const VERSION = "2.0.1"


### PR DESCRIPTION
Today, July 10th 2024, we have enabled the newrelic-fluent-bit-output Firelens Docker image replication to the new following AWS regions:
- `af-south-1`: Africa (Cape Town)
- `ca-west-1`: Canada (Calgary)
- `eu-central-2`: Europe (Zurich)
- `eu-south-1`: Europe (Milan)
- `eu-south-2`: Europe (Spain)
- `me-central-1`: Middle East (UAE)
- `me-south-1`: Middle East (Bahrain)

Merging this commit will publish a new image and have it replicated to the aforementioned regions.