### PR TITLE
Upgrade fluentbit version to 3.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:3.0.4
+FROM fluent/fluent-bit:3.1.2
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=3.0.4
+ARG FLUENTBIT_VERSION=3.1.2
 ARG WINDOWS_VERSION=ltsc2019
 
 #################################################

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:3.0.4-debug
+FROM fluent/fluent-bit:3.1.2-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1"
+const VERSION = "2.0.2"


### PR DESCRIPTION
### Notes
We have got a trivy ticket of the image [cf-registry.nr-ops.net/maas/docker-atlantis-fluent-bit](http://cf-registry.nr-ops.net/maas/docker-atlantis-fluent-bit), this image uses the image from this public repo from new relic: [GitHub - newrelic/newrelic-fluent-bit-output](https://github.com/newrelic/newrelic-fluent-bit-output). This is to bump up to the version to 3.1.2 the same version which [new relic packaged fluent bit](https://github.com/newrelic/fluent-bit-package/blob/a5758eb5431eeb4bd1a670688ddd836f719e32f2/versions/common.yml#L1) also supports.

### Testing
1. Local integ test passes `bash test.sh`.
2. Local build works.

