### PR TITLE
Bump fluent-bit to 3.2.2 and go version to 1.23.x

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -112,6 +112,7 @@ jobs:
         env:
           TRIVY_NON_SSL: true
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
         uses: aquasecurity/trivy-action@0.25.0
         with:
           image-ref: registry:5000/fb-output-plugin-${{ matrix.name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.7-bullseye AS builder
+FROM golang:1.23.6-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 
@@ -10,7 +10,7 @@ COPY nrclient/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/nrclient
 COPY record/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/record
 COPY utils/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/utils
 
-ENV SOURCE docker
+ENV SOURCE=docker
 
 # Not using default value here due to this: https://github.com/docker/buildx/issues/510
 ARG TARGETPLATFORM
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:3.1.9
+FROM fluent/fluent-bit:3.2.2
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=3.1.9
+ARG FLUENTBIT_VERSION=3.2.2
 ARG WINDOWS_VERSION=ltsc2019
 
 #################################################
@@ -30,7 +30,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 RUN choco install --yes --no-progress mingw git
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
 # The last 1.20.X version in chocolatey is 1.20.7
-RUN choco install --yes --no-progress golang --version=1.20.7
+RUN choco install --yes --no-progress golang --version=1.23.6
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"
@@ -152,7 +152,7 @@ RUN vcpkg install --recurse openssl --triplet x64-windows-static; `
 
 
 # Install Chocolatey and OpenSSL: https://github.com/StefanScherer/dockerfiles-windows/blob/main/openssl/Dockerfile
-ENV chocolateyUseWindowsCompression false
+ENV chocolateyUseWindowsCompression=false
 RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); `
   choco feature disable --name showDownloadProgress ; 
   # choco install -y openssl;

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.7-bullseye AS builder
+FROM golang:1.23.6-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:3.1.9-debug
+FROM fluent/fluent-bit:3.2.2-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.7-bullseye AS builder
+FROM golang:1.23.6-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 
@@ -10,7 +10,7 @@ COPY nrclient/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/nrclient
 COPY record/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/record
 COPY utils/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/utils
 
-ENV SOURCE docker
+ENV SOURCE=docker
 
 # Not using default value here due to this: https://github.com/docker/buildx/issues/510
 ARG TARGETPLATFORM
@@ -18,8 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-# aws-for-fluent-bit 2.32.2.20240516 is based on Fluent Bit 1.9.10: https://github.com/aws/aws-for-fluent-bit/releases/tag/v2.32.2.20240516
-FROM amazon/aws-for-fluent-bit:2.32.2.20240516
+FROM amazon/aws-for-fluent-bit:2.32.4
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -3,7 +3,6 @@ FROM golang:1.20.7-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 
-#hello-world
 
 COPY Makefile go.* *.go /go/src/github.com/newrelic/newrelic-fluent-bit-output/
 COPY config/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/config

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,7 +1,9 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.23.6-bullseye AS builder
+FROM golang:1.20.7-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
+
+#hello-world
 
 COPY Makefile go.* *.go /go/src/github.com/newrelic/newrelic-fluent-bit-output/
 COPY config/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/config
@@ -10,7 +12,7 @@ COPY nrclient/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/nrclient
 COPY record/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/record
 COPY utils/ /go/src/github.com/newrelic/newrelic-fluent-bit-output/utils
 
-ENV SOURCE=docker
+ENV SOURCE docker
 
 # Not using default value here due to this: https://github.com/docker/buildx/issues/510
 ARG TARGETPLATFORM
@@ -18,6 +20,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
+# aws-for-fluent-bit 2.32.2.20240516 is based on Fluent Bit 1.9.10: https://github.com/aws/aws-for-fluent-bit/releases/tag/v2.32.2.20240516
 FROM amazon/aws-for-fluent-bit:2.32.5
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,3 +1,4 @@
+# We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
 FROM golang:1.20.7-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
@@ -17,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM amazon/aws-for-fluent-bit:2.32.4
+FROM amazon/aws-for-fluent-bit:2.32.2.20240516
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.7-bullseye AS builder
+FROM golang:1.23.6-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM amazon/aws-for-fluent-bit:2.32.2.20240516
+FROM amazon/aws-for-fluent-bit:2.32.5
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,5 +1,4 @@
-# We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.23.6-bullseye AS builder
+FROM golang:1.20.7-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.1.0"
+const VERSION = "2.2.0"


### PR DESCRIPTION
Built the image locally on Mac computer,  ran it and validated the logs receiving on the Newrelic.

Modified the fluent-bit.conf file as follows to pass to the docker run command:
```
[SERVICE]
    Flush         1
    Daemon        Off
    Log_File      /dev/stdout
    Log_Level     debug

[INPUT]
    Name          tail
    Path          /test-log/test/test.log

[OUTPUT]
    Name          newrelic
    Match         *     
    licenseKey    xxxx
```

then created a test.log file with sample log messages written into it. test.log:
```
This is Rajeev testing on 10th Feb 2025, 5.29pm
This is Again Rajeev testing 10th Feb 2025, 5.35pm
```

Built the docker images using the following commands and ran it by mounting the volume locally:

```
docker build -t rkallempudi/newrelic-fluentbit-output . 

docker run -v /Users/rkallempudi/Desktop/git/newrelic-fluent-bit-output/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf -v /Users/rkallempudi/Desktop/git/newrelic-fluent-bit-output/rkallempudi-test:/test-log/test -e "LICENSE_KEY=xxx" -e "ENDPOINT=https://log-api.newrelic.com/log/v1"   rkallempudi/newrelic-fluentbit-output

docker build -t rkallempudi/newrelic-fluentbit-output-firelensx -f Dockerfile_firelens .
docker run -v /Users/rkallempudi/Desktop/git/newrelic-fluent-bit-output/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf -v /Users/rkallempudi/Desktop/git/newrelic-fluent-bit-output/rkallempudi-test:/test-log/test -e "LICENSE_KEY=xxx" -e "ENDPOINT=https://log-api.newrelic.com/log/v1"   rkallempudi/newrelic-fluentbit-output-firelens
```

Windows testing:

- Did the testing on WindowsServer-2019 with AMI: amazon/Windows_Server-2019-English-Full-Base-2025.02.13 
- Cloned the code onto windows server and built the image
 `docker build -f Dockerfile.windows -t newrelic/newrelic-fluentbit-output:development-windows-ltsc-2019-rkallempudi --build-arg WINDOWS_VERSION=ltsc2019-amd64 .
- Tested the logs using the command:
`docker run -v "C:\Users\Administrator\Desktop:c:\fb" -e "LICENSE_KEY=xxx" newrelic/newrelic-fluentbit-output:development-windows-ltsc-2019-rkallempudi fluent-bit -c "c:\fb\fb.config" -e "/fluent-bit/bin/out_newrelic.dll"
- Validated logs in NewRelic Logs view.



Done the docker trivy scan locally:
`trivy image --scanners=vuln --pkg-types=os --severity=HIGH,CRITICAL --ignore-unfixed rkallempudi/newrelic-fluentbit-output-firelens`


JFrog Scan reported one Critical and One High CVEs coming from upstream

<img width="1181" alt="Screenshot 2025-02-19 at 10 30 28 PM" src="https://github.com/user-attachments/assets/f4c46418-b6c7-4041-9eb2-a26ad72a1ef9" />


