### PR TITLE
go version change to 1.23.6

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -243,8 +243,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          username: ${{ secrets.SVC_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.SVC_DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and Publish Docker image for ${{ matrix.name }}
         env:

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-      - name: Set up Go 1.20.7
+      - name: Set up Go 1.23.6
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.23.6'
 
       - name: Check go version
         run: go version

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-      - name: Set up Go 1.20.7
+      - name: Set up Go 1.23.6
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.23.6'
         id: go
 
       - name: Check go version

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,17 +3,6 @@ name: New Relic Fluent Bit Output Plugin - Pull Request
 on: [pull_request]
 
 jobs:
-  testing-docker-login:
-    name: CI - Test docker login
-    runs-on: ubuntu-20.04
-
-    steps :
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
   unit-tests:
     name: CI - Tests and Build
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,17 @@ name: New Relic Fluent Bit Output Plugin - Pull Request
 on: [pull_request]
 
 jobs:
+  testing-docker-login:
+    name: CI - Test docker login
+    runs-on: ubuntu-20.04
+
+    steps :
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
   unit-tests:
     name: CI - Tests and Build
     runs-on: ubuntu-20.04

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.20.7-bullseye AS builder
+FROM golang:1.23.6-bullseye AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.2.0"
+const VERSION = "2.2.1"


### PR DESCRIPTION
This PR update CI/CD workflow to use go version 1.23.6 and Docker firelens image to use newer version of go 1.23.6