### PR TITLE
Update Go version to 1.23.7 and change base image to Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.23.6-bullseye AS builder
+FROM golang:1.23.7-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.3.0"
+const VERSION = "2.4.0"


### PR DESCRIPTION
This pull request updates the base image in our newrelic-fluentbit-output docker image to use Go version 1.23.7 and switches the operating system to Debian Bookworm