### PR TITLE
changed version in only docker files

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Set up Go 1.25.7
+      - name: Set up Go 1.25.8
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # git ls-remote https://github.com/actions/setup-go v5
         with:
           go-version: '1.25.7'

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.25.8
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # git ls-remote https://github.com/actions/setup-go v5
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.8'
 
       - name: Check go version
         run: go version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25.8-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:4.2.2
+FROM fluent/fluent-bit:4.2.4
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=4.2.2
+ENV FBVERSION=4.2.4
 # Note: Base image has CVE-2025-15467 (OpenSSL). Waiting for fluent-bit upstream to release patched version.
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=4.2.2
+ARG FLUENTBIT_VERSION=4.2.4
 ARG WINDOWS_VERSION=2022
 
 #################################################

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=4.2.4
+ARG FLUENTBIT_VERSION=4.2.3.1
 ARG WINDOWS_VERSION=2022
 
 #################################################

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -28,7 +28,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.25.8
+RUN choco install --yes --no-progress golang --version=1.24.6
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -28,7 +28,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.24.6
+RUN choco install --yes --no-progress golang --version=1.25.8
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -18,9 +18,9 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:4.2.2-debug
+FROM fluent/fluent-bit:4.2.4-debug
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=4.2.2-debug
+ENV FBVERSION=4.2.4-debug
 # Note: Base image has CVE-2025-15467 (OpenSSL). Waiting for fluent-bit upstream to release patched version.
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25.8-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25.8-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -18,7 +18,7 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-
+    # aws-for-fluent-bit 3.2.5 is based on Fluent Bit 4.2.2: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.2.5
 FROM amazon/aws-for-fluent-bit:3.2.5
 
 # Expose this env variable so that the version can be used in the helm chart

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -18,11 +18,11 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-    # aws-for-fluent-bit 3.2.1 is based on Fluent Bit 4.2.2: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.2.1
-FROM amazon/aws-for-fluent-bit:3.2.1
+
+FROM amazon/aws-for-fluent-bit:3.2.5
 
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=4.2.2
+ENV FBVERSION=4.2.4
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/newrelic-fluent-bit-output
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/fluent/fluent-bit-go v0.0.0-20230731091245-a7a013e2473c

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "3.4.1"
+const VERSION = "3.5.0"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "3.4.0"
+const VERSION = "3.4.1"


### PR DESCRIPTION
<img width="1482" height="742" alt="Screenshot 2026-04-10 at 1 01 13 PM" src="https://github.com/user-attachments/assets/eb3a42f3-00f4-4c48-ac2f-c0557a3cb312" />

Successfully tested this dockerfile in local. Showing **plugin.version** = 3.4.1 

Comparison of **trivy scan** for current **go version(1.25.7)** and **fluent-bit-image version - 4.2.2**
<img width="1980" height="812" alt="image" src="https://github.com/user-attachments/assets/4a19087c-7c0d-4d06-b5d2-686e2cd14206" />

Comparison of **trivy scan** for current **go version(1.25.8)** and **fluent-bit-image version - 4.2.4**
<img width="2334" height="836" alt="image" src="https://github.com/user-attachments/assets/d43b1b87-e921-4bf5-b72d-19e924293c0c" />

trivy and jfrog result for both 
https://docs.google.com/spreadsheets/d/1s4uWvU1ab_npZ-DtRfpy83QEL68wKCunL-PTc9pjQwI/edit?gid=1985882433#gid=1985882433


**NOTE:**

1. For windows, fluen-bit 4.2.3.1 base version is used as 4.2.4 is not yet relesed in docker hub.
2. For linux, we are using 4.2.4 version which resolves most of the high and critical vulnerabilites.
3. For docker firelens image we are using 3.2.5 version which uses fluent bit 4.2.2 base version as it is also not released for 4.2.4