### PR TITLE
Fluent bit 5.0.6 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,9 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:4.2.4
+FROM fluent/fluent-bit:5.0.6
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=4.2.4
-# Note: Base image has CVE-2025-15467 (OpenSSL). Waiting for fluent-bit upstream to release patched version.
+ENV FBVERSION=5.0.6
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=4.2.3.1
+ARG FLUENTBIT_VERSION=5.0.6
 ARG WINDOWS_VERSION=2022
 
 #################################################

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -18,10 +18,9 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:4.2.4-debug
+FROM fluent/fluent-bit:5.0.6-debug
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=4.2.4-debug
-# Note: Base image has CVE-2025-15467 (OpenSSL). Waiting for fluent-bit upstream to release patched version.
+ENV FBVERSION=5.0.6-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -22,7 +22,7 @@ RUN make ${TARGETPLATFORM}
 FROM amazon/aws-for-fluent-bit:3.4.0
 
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=5.0.6
+ENV FBVERSION=5.0.5
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -18,8 +18,8 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-    # aws-for-fluent-bit 3.3.2 is based on Fluent Bit 5.0.3: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.3.2
-FROM amazon/aws-for-fluent-bit:3.3.2
+    # aws-for-fluent-bit 3.4.0 is based on Fluent Bit 5.0.5: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.4.0
+FROM amazon/aws-for-fluent-bit:3.4.0
 
 # Expose this env variable so that the version can be used in the helm chart
 ENV FBVERSION=5.0.6

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -18,11 +18,11 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-    # aws-for-fluent-bit 3.2.5 is based on Fluent Bit 4.2.2: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.2.5
-FROM amazon/aws-for-fluent-bit:3.2.5
+    # aws-for-fluent-bit 3.3.2 is based on Fluent Bit 5.0.3: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.3.2
+FROM amazon/aws-for-fluent-bit:3.3.2
 
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=4.2.4
+ENV FBVERSION=5.0.6
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "3.5.2"
+const VERSION = "3.6.0"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "3.5.1"
+const VERSION = "3.5.2"


### PR DESCRIPTION
Changes:

1. Dockerfile: base bumped fluent/fluent-bit:4.2.4 → 5.0.6; FBVERSION=5.0.6, removed stale CVE comment.
2. Dockerfile_debug: base bumped fluent/fluent-bit:4.2.4-debug → 5.0.6-debug; FBVERSION=5.0.6-debug, removed stale CVE comment.
3. Dockerfile.windows: FLUENTBIT_VERSION=4.2.3.1 → 5.0.6.
4. Dockerfile_firelens: bumped amazon/aws-for-fluent-bit 3.2.5 → 3.4.0 (latest AWS-supported tag, bundles FB 5.0.5). Set FBVERSION=5.0.5 since AWS FireLens hasn't released 5.0.6 yet.
https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.4.0