### PR TITLE
fix: upgrade Go to 1.26.4 and Fluent Bit to 5.0.8

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Set up Go 1.25.9
+      - name: Set up Go 1.26.4
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # git ls-remote https://github.com/actions/setup-go v5
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.4'
 
       - name: Check go version
         run: go version

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Set up Go 1.25.9
+      - name: Set up Go 1.26.4
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.4'
         id: go
 
       - name: Check go version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 
@@ -17,9 +17,9 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:5.0.6
+FROM fluent/fluent-bit:5.0.8
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=5.0.6
+ENV FBVERSION=5.0.8
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=5.0.6
+ARG FLUENTBIT_VERSION=5.0.8
 ARG WINDOWS_VERSION=2022
 
 #################################################
@@ -28,7 +28,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.24.6
+RUN choco install --yes --no-progress golang --version=1.26.4
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=5.0.7
+ARG FLUENTBIT_VERSION=5.0.6
 ARG WINDOWS_VERSION=2022
 
 #################################################

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=5.0.8
+ARG FLUENTBIT_VERSION=5.0.7
 ARG WINDOWS_VERSION=2022
 
 #################################################

--- a/Dockerfile.windows_older
+++ b/Dockerfile.windows_older
@@ -29,7 +29,7 @@ RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Base Dependencies
 RUN choco install --yes --no-progress mingw git
-RUN choco install --yes --no-progress golang --version=1.24.6
+RUN choco install --yes --no-progress golang --version=1.26.4
 
 # Put the path before the other paths so that MinGW shadows Windows commands.
 RUN setx PATH "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw\bin;%PATH%"

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -1,5 +1,5 @@
 # We can't go past 1.20.X until this issue is solved: https://github.com/golang/go/issues/62130#issuecomment-1687335898
-FROM golang:1.25.9-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 
@@ -18,9 +18,9 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:5.0.6-debug
+FROM fluent/fluent-bit:5.0.8-debug
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=5.0.6-debug
+ENV FBVERSION=5.0.8-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -1,4 +1,4 @@
-FROM golang:1.25.9-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 WORKDIR /go/src/github.com/newrelic/newrelic-fluent-bit-output
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -18,11 +18,11 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-    # aws-for-fluent-bit 3.4.0 is based on Fluent Bit 5.0.5: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.4.0
-FROM amazon/aws-for-fluent-bit:3.4.0
+    # aws-for-fluent-bit 3.4.5 is based on Fluent Bit 5.0.7: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.4.5
+FROM amazon/aws-for-fluent-bit:3.4.5
 
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=5.0.5
+ENV FBVERSION=5.0.7
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/newrelic-fluent-bit-output
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/fluent/fluent-bit-go v0.0.0-20230731091245-a7a013e2473c

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "3.6.0"
+const VERSION = "3.7.0"


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                     
  - Upgraded Go version to 1.26.4 across all Dockerfiles, go.mod, and CI workflows                                                                                                                               
  - Upgraded Fluent Bit version to 5.0.8 in Linux                                                                                                                                
                                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                                     
  - **Go 1.26.4**: Updated in `go.mod`, `Dockerfile`, `Dockerfile_debug`, `Dockerfile_firelens`, `Dockerfile.windows`, `Dockerfile.windows_older`, `.github/workflows/pr.yaml`,                                  
  `.github/workflows/merge-to-master.yml`                                                                                                                                                                        
  - **Fluent Bit 5.0.8**: Updated in `Dockerfile`, `Dockerfile_debug`, `Dockerfile.windows`                                                                                                                      
                                                                                                                                                                                                                 
  ## Motivation                                                                                                                                                                                                  
  Upgrade to latest patch versions to address CVEs and security vulnerabilities.                                                                                                                                 
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                   
  - [ ] CI pipeline passes with new Go version                                                                                                                                                                   
  - [ ] Docker images build successfully                                                                                                                                                                         
  - [ ] Plugin functions correctly with Fluent Bit 5.0.8 
  
<img width="1728" height="702" alt="Screenshot 2026-06-30 at 3 16 31 PM" src="https://github.com/user-attachments/assets/5e4dc61b-b33a-4316-a216-56ebab8bc5de" />

