### PR TITLE
fix: override Windows base image to fix CVEs in ltsc2022 Docker image

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -52,14 +52,19 @@ RUN setx CXX "x86_64-w64-mingw32-g++"
 RUN go build -buildmode=c-shared -o out_newrelic.dll .
 
 #######################################################
-# Runtime Image - Fluent Bit image + include our plugin
+# Runtime Image - Fresh Windows base + Fluent Bit binaries + our plugin
 #######################################################
-FROM fluent/fluent-bit:windows-${WINDOWS_VERSION}-${FLUENTBIT_VERSION} as runtime
+FROM fluent/fluent-bit:windows-${WINDOWS_VERSION}-${FLUENTBIT_VERSION} AS fluentbit
+
+FROM mcr.microsoft.com/windows/servercore:ltsc${WINDOWS_VERSION} AS runtime
 
 ARG FLUENTBIT_VERSION
 # Expose this env variable so that the version can be used in the helm chart
 ENV FBVERSION=${FLUENTBIT_VERSION}
 
+COPY --from=fluentbit /fluent-bit /fluent-bit
 COPY --from=nrBuilder /build/out_newrelic.dll /fluent-bit/bin/out_newrelic.dll
+
+RUN setx /M PATH "%PATH%;C:\fluent-bit\bin"
 
 CMD ["fluent-bit.exe", "-i", "dummy", "-o", "stdout", "-e", "/fluent-bit/bin/out_newrelic.dll"]

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "3.7.0"
+const VERSION = "3.7.1"


### PR DESCRIPTION
Problem

The newrelic-fluentbit-output Windows Docker image (windows-ltsc-2022) inherits the Windows base image from fluent/fluent-bit, which bundles an outdated Windows Server 2022 base (OS build 10.0.20348.5139). This caused Microsoft Partner Center certification to fail with 269 CVEs (Critical/High) when publishing the AKS extension CNAB bundle.

Solution

Override the runtime base image with a fresh mcr.microsoft.com/windows/servercore:ltsc2022 pulled directly from Microsoft, which includes the latest patches. The Fluent Bit binaries and configs are copied from the fluent/fluent-bit image into the patched base.

Note: This fix is temporary. By overriding the base image with mcr.microsoft.com/windows/servercore:ltsc2022, we ensure the latest patched Windows base is used at build time. However, as Microsoft releases new Windows patches, the image will need to be rebuilt and republished to stay compliant with Microsoft certification requirements. A permanent fix would require fluent/fluent-bit to regularly rebuild their Windows images with the latest base — we have raised an issue with them requesting this.

Testing

Manually tested on a Windows Server 2022 EC2 instance (ami-014b12c079f7d65d5, OS build 20348.5386) with Docker:
1. Built the image from this branch using Dockerfile.windows with WINDOWS_VERSION=2022
2. Verified Windows base image version — confirmed container runs on OS build 20348.5386 (the patched version required by Microsoft, fixing the reported CVEs)
3. Verified plugin loads — out_newrelic.dll loaded successfully with no errors
4. Verified log forwarding — ran the container with a tail input and confirmed logs were successfully forwarded to New Relic Logs UI
