### PR TITLE
Add Windows Server 2025 (LTSC) Docker image support

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -243,6 +243,12 @@ jobs:
             imageTagSuffix: windows-ltsc-2022
             runsOn: windows-2022
             isolation: process
+          - name: Windows Server 2025 (LTSC)
+            windowsVersion: 2025
+            windowsImageTag: ltsc2025-amd64
+            imageTagSuffix: windows-ltsc-2025
+            runsOn: windows-2025
+            isolation: process
 
     runs-on: ${{ matrix.runsOn }}
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -156,6 +156,12 @@ jobs:
             imageTagSuffix: windows-ltsc-2022
             runsOn: windows-2022
             isolation: process
+          - name: windows 2025 (LTSC)
+            windowsVersion: 2025
+            windowsImageTag: ltsc2025-amd64
+            imageTagSuffix: windows-ltsc-2025
+            runsOn: windows-2025
+            isolation: process
 
     runs-on: ${{ matrix.runsOn }}
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "3.8.0"
+const VERSION = "3.8.1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "3.8.1"
+const VERSION = "3.9.0"


### PR DESCRIPTION
## What it does

- Adds a windows-ltsc-2025 matrix entry to pr.yaml and merge-to-master.yml, same pattern as the existing 2022 entry. No Dockerfile.windows changes needed.
- Bumps version.go to 3.9.0

## Testing

- CI built and pushed the Windows Server 2025 image successfully.
- Separately verified Fluent Bit runs correctly on a real Windows Server 2025 instance (via fluent-bit-package).