### PR TITLE
upgrading the fluent bit version to 5.0.9

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -164,12 +164,8 @@ jobs:
         run: |
           docker build --platform windows/amd64 --isolation=${{ matrix.isolation }} -f Dockerfile.windows -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} --build-arg WINDOWS_VERSION=${{ matrix.windowsVersion }} .
 
-      # Non-blocking for now: container-to-host networking (via the Docker NAT gateway) and
-      # Windows Firewall behavior on this runner are unproven. See test/test-windows.ps1 for
-      # what this checks and Claude_hrai.md for context. Once proven reliable, drop
-      # continue-on-error to make this a real gate.
+      # Run time test for windows
       - name: Functional test for ${{ matrix.name }} (non-blocking)
-        continue-on-error: true
         shell: pwsh
         env:
           DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -164,6 +164,18 @@ jobs:
         run: |
           docker build --platform windows/amd64 --isolation=${{ matrix.isolation }} -f Dockerfile.windows -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }} --build-arg WINDOWS_VERSION=${{ matrix.windowsVersion }} .
 
+      # Non-blocking for now: container-to-host networking (via the Docker NAT gateway) and
+      # Windows Firewall behavior on this runner are unproven. See test/test-windows.ps1 for
+      # what this checks and Claude_hrai.md for context. Once proven reliable, drop
+      # continue-on-error to make this a real gate.
+      - name: Functional test for ${{ matrix.name }} (non-blocking)
+        continue-on-error: true
+        shell: pwsh
+        env:
+          DOCKERHUB_REPOSITORY: newrelic/newrelic-fluentbit-output
+          IMAGE_TAG: development-${{ matrix.imageTagSuffix }}
+        run: |
+          ./test/test-windows.ps1 -Image "${{ env.DOCKERHUB_REPOSITORY }}:${{ env.IMAGE_TAG }}"
 
   docker-windows-ci-older-version:
     name:  CI - Docker image for ${{ matrix.name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:5.0.8
+FROM fluent/fluent-bit:5.0.9
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=5.0.8
+ENV FBVERSION=5.0.9
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG FLUENTBIT_VERSION=5.0.6
+ARG FLUENTBIT_VERSION=5.0.9
 ARG WINDOWS_VERSION=2022
 
 #################################################

--- a/Dockerfile_debug
+++ b/Dockerfile_debug
@@ -18,9 +18,9 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-FROM fluent/fluent-bit:5.0.8-debug
+FROM fluent/fluent-bit:5.0.9-debug
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=5.0.8-debug
+ENV FBVERSION=5.0.9-debug
 
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -22,7 +22,7 @@ RUN make ${TARGETPLATFORM}
 FROM amazon/aws-for-fluent-bit:3.4.5
 
 # Expose this env variable so that the version can be used in the helm chart
-ENV FBVERSION=5.0.7
+ENV FBVERSION=5.0.9
 COPY --from=builder /go/src/github.com/newrelic/newrelic-fluent-bit-output/out_newrelic-linux-*.so /fluent-bit/bin/out_newrelic.so
 COPY *.conf /fluent-bit/etc/
 

--- a/Dockerfile_firelens
+++ b/Dockerfile_firelens
@@ -18,8 +18,8 @@ ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM} architecture"
 RUN make ${TARGETPLATFORM}
 
-    # aws-for-fluent-bit 3.4.5 is based on Fluent Bit 5.0.7: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.4.5
-FROM amazon/aws-for-fluent-bit:3.4.5
+    # aws-for-fluent-bit 3.4.11 is based on Fluent Bit 5.0.9: https://github.com/aws/aws-for-fluent-bit/releases/tag/v3.4.11
+FROM amazon/aws-for-fluent-bit:3.4.11
 
 # Expose this env variable so that the version can be used in the helm chart
 ENV FBVERSION=5.0.9

--- a/test/docker-compose.windows.yml
+++ b/test/docker-compose.windows.yml
@@ -1,0 +1,19 @@
+services:
+  newrelic-fluent-bit-output:
+    image: "${NR_FB_IMAGE}"
+    container_name: "${CONTAINER_NAME}"
+    ports:
+      - "${HEALTH_PORT}:${HEALTH_PORT}"
+    volumes:
+      - "${TESTDATA_DIR}:C:\\testdata"
+      - "${CONF_DIR}:C:\\fluent-bit\\etc"
+    environment:
+      FILE_PATH: "C:\\testdata\\fbtest.log"
+      API_KEY: "some-insert-key"
+      ENDPOINT: "${ENDPOINT}"
+    command: ["fluent-bit.exe", "-c", "C:\\fluent-bit\\etc\\fluent-bit.conf", "-e", "C:\\fluent-bit\\bin\\out_newrelic.dll"]
+
+networks:
+  default:
+    name: "${NETWORK_NAME}"
+    external: true

--- a/test/fluent-bit.windows.conf
+++ b/test/fluent-bit.windows.conf
@@ -2,10 +2,15 @@
     Flush         1
     Daemon        Off
     Log_File      /dev/stdout
+    HTTP_Server   On
+    HTTP_Listen   0.0.0.0
+    HTTP_Port     2020
+    Health_Check  On
 
 [INPUT]
     Name          tail
     Path          ${FILE_PATH}
+    DB            C:\testdata\flb.db
 
 [OUTPUT]
     Name          newrelic

--- a/test/fluent-bit.windows.conf
+++ b/test/fluent-bit.windows.conf
@@ -1,0 +1,15 @@
+[SERVICE]
+    Flush         1
+    Daemon        Off
+    Log_File      /dev/stdout
+
+[INPUT]
+    Name          tail
+    Path          ${FILE_PATH}
+
+[OUTPUT]
+    Name          newrelic
+    Match         *
+    apiKey        ${API_KEY}
+    licenseKey    ${LICENSE_KEY}
+    endpoint      ${ENDPOINT}

--- a/test/test-windows.ps1
+++ b/test/test-windows.ps1
@@ -1,0 +1,202 @@
+<#
+.SYNOPSIS
+    Windows functional/runtime test for the newrelic-fluent-bit-output Windows image.
+    Analogous to test.sh: starts a mock New Relic endpoint (the real MockServer, run as a
+    standalone Windows process since no Windows-container image exists for it), runs the
+    built plugin image against it, and verifies the logs actually arrive.
+
+.PARAMETER Image
+    The newrelic-fluent-bit-output Windows Docker image tag to test.
+
+.PARAMETER MockServerVersion
+    MockServer release version to download (tag is "mockserver-<version>" on
+    https://github.com/mock-server/mockserver-monorepo/releases).
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Image,
+
+    [string]$MockServerVersion = "7.5.0"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$TestDir = $PSScriptRoot
+$WorkDir = Join-Path $TestDir ".windows-test-work"
+$TestDataDir = Join-Path $TestDir "testdata-windows"
+$NetworkName = "wintest-net"
+$ContainerName = "fb-windows-test"
+$FirewallRuleName = "newrelic-fb-mockserver-test-1080"
+$MockServerPort = 1080
+
+$mockServerProcess = $null
+$mockServerOutLog = Join-Path $WorkDir "mockserver-out.log"
+$mockServerErrLog = Join-Path $WorkDir "mockserver-err.log"
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "==> $Message"
+}
+
+function Test-MockServerReady {
+    try {
+        $resp = Invoke-WebRequest -Method PUT -Uri "http://localhost:$MockServerPort/mockserver/status" `
+            -UseBasicParsing -TimeoutSec 5
+        return $resp.StatusCode -eq 200
+    }
+    catch {
+        return $false
+    }
+}
+
+function Test-LogsDelivered {
+    param([string]$VerifyBody)
+    try {
+        $resp = Invoke-WebRequest -Method PUT -Uri "http://localhost:$MockServerPort/mockserver/verify" `
+            -Body $VerifyBody -ContentType "application/json" -UseBasicParsing -TimeoutSec 5
+        return $resp.StatusCode -eq 202
+    }
+    catch {
+        return $false
+    }
+}
+
+function Wait-Until {
+    param(
+        [scriptblock]$Condition,
+        [string]$Description,
+        [int]$MaxRetries = 10,
+        [int]$DelaySeconds = 2
+    )
+    for ($i = 0; $i -le $MaxRetries; $i++) {
+        if (& $Condition) {
+            return $true
+        }
+        Write-Host "Waiting for $Description. Trying again in ${DelaySeconds}s. Try #$i"
+        Start-Sleep -Seconds $DelaySeconds
+    }
+    return $false
+}
+
+function Remove-PreviousRunLeftovers {
+    docker rm -f $ContainerName 2>$null | Out-Null
+    docker network rm $NetworkName 2>$null | Out-Null
+    if (Test-Path $TestDataDir) { Remove-Item -Recurse -Force $TestDataDir -ErrorAction SilentlyContinue }
+    if (Test-Path $WorkDir) { Remove-Item -Recurse -Force $WorkDir -ErrorAction SilentlyContinue }
+    Remove-NetFirewallRule -DisplayName $FirewallRuleName -ErrorAction SilentlyContinue
+}
+
+function Invoke-Cleanup {
+    Write-Step "Cleaning up"
+
+    docker rm -f $ContainerName 2>$null | Out-Null
+    docker network rm $NetworkName 2>$null | Out-Null
+
+    if ($mockServerProcess -and -not $mockServerProcess.HasExited) {
+        Stop-Process -Id $mockServerProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+
+    Remove-NetFirewallRule -DisplayName $FirewallRuleName -ErrorAction SilentlyContinue
+
+    if (Test-Path $TestDataDir) { Remove-Item -Recurse -Force $TestDataDir -ErrorAction SilentlyContinue }
+    if (Test-Path $WorkDir) { Remove-Item -Recurse -Force $WorkDir -ErrorAction SilentlyContinue }
+}
+
+try {
+    Remove-PreviousRunLeftovers
+
+    New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+
+    Write-Step "Downloading MockServer $MockServerVersion (Windows bundle)"
+    $zipUrl = "https://github.com/mock-server/mockserver-monorepo/releases/download/mockserver-$MockServerVersion/mockserver-$MockServerVersion-windows-x86_64.zip"
+    $zipPath = Join-Path $WorkDir "mockserver.zip"
+    Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath
+
+    Write-Step "Extracting MockServer bundle"
+    Expand-Archive -Path $zipPath -DestinationPath $WorkDir -Force
+    $mockServerDir = Get-ChildItem -Path $WorkDir -Directory | Where-Object { $_.Name -like "mockserver-*" } | Select-Object -First 1
+    if (-not $mockServerDir) {
+        throw "Could not find extracted MockServer directory under $WorkDir"
+    }
+    $mockServerBat = Join-Path $mockServerDir.FullName "bin\mockserver.bat"
+
+    Write-Step "Starting MockServer on port $MockServerPort"
+    $initJson = Join-Path $RepoRoot "test\expectations.json"
+    $mockServerProcess = Start-Process -FilePath $mockServerBat `
+        -ArgumentList @("run", "-p", "$MockServerPort", "--init", $initJson) `
+        -RedirectStandardOutput $mockServerOutLog `
+        -RedirectStandardError $mockServerErrLog `
+        -WindowStyle Hidden -PassThru
+
+    if (-not (Wait-Until -Condition { Test-MockServerReady } -Description "MockServer to be ready" -MaxRetries 15 -DelaySeconds 2)) {
+        Write-Host "MockServer failed to start. stdout:"
+        if (Test-Path $mockServerOutLog) { Get-Content $mockServerOutLog }
+        Write-Host "MockServer failed to start. stderr:"
+        if (Test-Path $mockServerErrLog) { Get-Content $mockServerErrLog }
+        throw "MockServer did not become ready in time"
+    }
+    Write-Step "MockServer is ready"
+
+    Write-Step "Opening firewall for inbound TCP $MockServerPort (needed for the Windows container to reach the host)"
+    New-NetFirewallRule -DisplayName $FirewallRuleName -Direction Inbound -Protocol TCP -LocalPort $MockServerPort -Action Allow | Out-Null
+
+    Write-Step "Creating a dedicated Docker NAT network"
+    docker network create -d nat $NetworkName | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to create Docker network $NetworkName"
+    }
+    $networkInfo = docker network inspect $NetworkName | ConvertFrom-Json
+    $gatewayIp = $networkInfo[0].IPAM.Config[0].Gateway
+    if (-not $gatewayIp) {
+        throw "Could not resolve gateway IP for network $NetworkName"
+    }
+    Write-Step "Resolved host gateway IP: $gatewayIp (this is how the container reaches the host-run MockServer)"
+    $endpoint = "http://${gatewayIp}:${MockServerPort}/log/v1"
+
+    Write-Step "Preparing test log file"
+    New-Item -ItemType Directory -Force -Path $TestDataDir | Out-Null
+    $logFile = Join-Path $TestDataDir "fbtest.log"
+    New-Item -ItemType File -Force -Path $logFile | Out-Null
+
+    Write-Step "Starting the newrelic-fluent-bit-output Windows container"
+    $confPath = Join-Path $TestDir "fluent-bit.windows.conf"
+    docker run -d --name $ContainerName --network $NetworkName `
+        -v "${TestDataDir}:C:\testdata" `
+        -v "${confPath}:C:\fluent-bit\etc\fluent-bit.conf" `
+        -e "FILE_PATH=C:\testdata\fbtest.log" `
+        -e "API_KEY=some-insert-key" `
+        -e "ENDPOINT=$endpoint" `
+        $Image `
+        fluent-bit.exe -c C:\fluent-bit\etc\fluent-bit.conf -e C:\fluent-bit\bin\out_newrelic.dll | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to start container $ContainerName from image $Image"
+    }
+
+    Write-Step "Sending test log lines"
+    1..5 | ForEach-Object { Add-Content -Path $logFile -Value "Hello!" }
+
+    $verifyBody = Get-Content (Join-Path $RepoRoot "test\verification.json") -Raw
+
+    Write-Step "Waiting for logs to reach MockServer"
+    if (-not (Wait-Until -Condition { Test-LogsDelivered -VerifyBody $verifyBody } -Description "logs to arrive at MockServer" -MaxRetries 10 -DelaySeconds 2)) {
+        Write-Host "Logs did not reach MockServer in time. Diagnostics:"
+        Write-Host "--- newrelic-fluent-bit-output container logs ---"
+        docker logs $ContainerName
+        Write-Host "--- MockServer stdout ---"
+        if (Test-Path $mockServerOutLog) { Get-Content $mockServerOutLog }
+        Write-Host "--- MockServer stderr ---"
+        if (Test-Path $mockServerErrLog) { Get-Content $mockServerErrLog }
+        throw "Functional test failed: logs never reached the mock New Relic endpoint"
+    }
+
+    Write-Step "Success! Logs reached the mock New Relic endpoint."
+    exit 0
+}
+catch {
+    Write-Host "Windows functional test failed: $_"
+    exit 1
+}
+finally {
+    Invoke-Cleanup
+}

--- a/test/test-windows.ps1
+++ b/test/test-windows.ps1
@@ -29,6 +29,8 @@ $NetworkName = "wintest-net"
 $ContainerName = "fb-windows-test"
 $FirewallRuleName = "newrelic-fb-mockserver-test-1080"
 $MockServerPort = 1080
+$HealthPort = 2020
+$DbFileName = "flb.db"
 
 $mockServerProcess = $null
 $mockServerOutLog = Join-Path $WorkDir "mockserver-out.log"
@@ -56,6 +58,28 @@ function Test-LogsDelivered {
         $resp = Invoke-WebRequest -Method PUT -Uri "http://localhost:$MockServerPort/mockserver/verify" `
             -Body $VerifyBody -ContentType "application/json" -UseBasicParsing -TimeoutSec 5
         return $resp.StatusCode -eq 202
+    }
+    catch {
+        return $false
+    }
+}
+
+function Test-ContainerRunning {
+    param([string]$Name)
+    try {
+        $status = docker inspect -f "{{.State.Running}}" $Name 2>$null
+        return ($LASTEXITCODE -eq 0) -and ($status.Trim() -eq "true")
+    }
+    catch {
+        return $false
+    }
+}
+
+function Test-FluentBitHealthy {
+    param([int]$Port)
+    try {
+        $resp = Invoke-WebRequest -Method GET -Uri "http://localhost:$Port/api/v1/health" -UseBasicParsing -TimeoutSec 5
+        return $resp.StatusCode -eq 200
     }
     catch {
         return $false
@@ -167,6 +191,7 @@ try {
     New-Item -ItemType Directory -Force -Path $confDir | Out-Null
     Copy-Item -Path (Join-Path $TestDir "fluent-bit.windows.conf") -Destination (Join-Path $confDir "fluent-bit.conf") -Force
     docker run -d --name $ContainerName --network $NetworkName `
+        -p "${HealthPort}:${HealthPort}" `
         -v "${TestDataDir}:C:\testdata" `
         -v "${confDir}:C:\fluent-bit\etc" `
         -e "FILE_PATH=C:\testdata\fbtest.log" `
@@ -194,8 +219,40 @@ try {
         if (Test-Path $mockServerErrLog) { Get-Content $mockServerErrLog }
         throw "Functional test failed: logs never reached the mock New Relic endpoint"
     }
+    Write-Step "Logs reached the mock New Relic endpoint."
 
-    Write-Step "Success! Logs reached the mock New Relic endpoint."
+    # Regression check for https://github.com/fluent/fluent-bit/issues/11904: Fluent Bit crashed
+    # on Windows ("[BUG !] Bug found in _mk_event_del()") when HTTP_Server + Health_Check were
+    # enabled. HTTP_Server/Health_Check are already on in fluent-bit.windows.conf, so watch the
+    # container over a window to confirm it doesn't crash and the health endpoint responds.
+    Write-Step "Watching for a regression of fluent/fluent-bit#11904 (HTTP_Server crash) for 60s"
+    $crashCheckIterations = 12
+    $crashCheckDelaySeconds = 5
+    $sawHealthyResponse = $false
+    for ($i = 0; $i -lt $crashCheckIterations; $i++) {
+        if (-not (Test-ContainerRunning -Name $ContainerName)) {
+            Write-Host "--- Container exited. Logs: ---"
+            docker logs $ContainerName
+            throw "Container exited while HTTP_Server was enabled - possible regression of fluent/fluent-bit#11904"
+        }
+        if (Test-FluentBitHealthy -Port $HealthPort) {
+            $sawHealthyResponse = $true
+        }
+        Start-Sleep -Seconds $crashCheckDelaySeconds
+    }
+    if (-not $sawHealthyResponse) {
+        throw "Health endpoint at port $HealthPort never responded with 200 - HTTP_Server may not have started correctly"
+    }
+    Write-Step "No crash after $($crashCheckIterations * $crashCheckDelaySeconds)s with HTTP_Server + Health_Check enabled"
+
+    Write-Step "Checking DB persistence file was created (mirrors fluentBit.windowsDb in the Helm chart)"
+    $dbFile = Join-Path $TestDataDir $DbFileName
+    if (-not (Test-Path $dbFile)) {
+        throw "Expected DB persistence file was not created at $dbFile"
+    }
+    Write-Step "DB persistence file confirmed at $dbFile"
+
+    Write-Step "Success! Logs delivered, no HTTP_Server crash, DB persistence confirmed."
     exit 0
 }
 catch {

--- a/test/test-windows.ps1
+++ b/test/test-windows.ps1
@@ -160,10 +160,15 @@ try {
     New-Item -ItemType File -Force -Path $logFile | Out-Null
 
     Write-Step "Starting the newrelic-fluent-bit-output Windows container"
-    $confPath = Join-Path $TestDir "fluent-bit.windows.conf"
+    # Windows containers only support directory-level bind mounts (single-file mounts fail with
+    # "invalid mount config for type bind: source path must be a directory"), so stage the conf
+    # in its own directory rather than mounting test/fluent-bit.windows.conf directly.
+    $confDir = Join-Path $WorkDir "etc"
+    New-Item -ItemType Directory -Force -Path $confDir | Out-Null
+    Copy-Item -Path (Join-Path $TestDir "fluent-bit.windows.conf") -Destination (Join-Path $confDir "fluent-bit.conf") -Force
     docker run -d --name $ContainerName --network $NetworkName `
         -v "${TestDataDir}:C:\testdata" `
-        -v "${confPath}:C:\fluent-bit\etc\fluent-bit.conf" `
+        -v "${confDir}:C:\fluent-bit\etc" `
         -e "FILE_PATH=C:\testdata\fbtest.log" `
         -e "API_KEY=some-insert-key" `
         -e "ENDPOINT=$endpoint" `

--- a/test/test-windows.ps1
+++ b/test/test-windows.ps1
@@ -27,6 +27,8 @@ $WorkDir = Join-Path $TestDir ".windows-test-work"
 $TestDataDir = Join-Path $TestDir "testdata-windows"
 $NetworkName = "wintest-net"
 $ContainerName = "fb-windows-test"
+$ComposeProject = "fbwintest"
+$ComposeFile = Join-Path $PSScriptRoot "docker-compose.windows.yml"
 $FirewallRuleName = "newrelic-fb-mockserver-test-1080"
 $MockServerPort = 1080
 $HealthPort = 2020
@@ -104,6 +106,8 @@ function Wait-Until {
 }
 
 function Remove-PreviousRunLeftovers {
+    # Env vars for docker-compose.windows.yml aren't set yet this early, so fall back to a plain
+    # container removal rather than `docker compose down` (which would warn about unset variables).
     docker rm -f $ContainerName 2>$null | Out-Null
     docker network rm $NetworkName 2>$null | Out-Null
     if (Test-Path $TestDataDir) { Remove-Item -Recurse -Force $TestDataDir -ErrorAction SilentlyContinue }
@@ -114,6 +118,7 @@ function Remove-PreviousRunLeftovers {
 function Invoke-Cleanup {
     Write-Step "Cleaning up"
 
+    docker compose -f $ComposeFile -p $ComposeProject down --remove-orphans 2>$null | Out-Null
     docker rm -f $ContainerName 2>$null | Out-Null
     docker network rm $NetworkName 2>$null | Out-Null
 
@@ -183,24 +188,30 @@ try {
     $logFile = Join-Path $TestDataDir "fbtest.log"
     New-Item -ItemType File -Force -Path $logFile | Out-Null
 
-    Write-Step "Starting the newrelic-fluent-bit-output Windows container"
+    Write-Step "Starting the newrelic-fluent-bit-output Windows container (via docker-compose.windows.yml)"
     # Windows containers only support directory-level bind mounts (single-file mounts fail with
     # "invalid mount config for type bind: source path must be a directory"), so stage the conf
     # in its own directory rather than mounting test/fluent-bit.windows.conf directly.
     $confDir = Join-Path $WorkDir "etc"
     New-Item -ItemType Directory -Force -Path $confDir | Out-Null
     Copy-Item -Path (Join-Path $TestDir "fluent-bit.windows.conf") -Destination (Join-Path $confDir "fluent-bit.conf") -Force
-    docker run -d --name $ContainerName --network $NetworkName `
-        -p "${HealthPort}:${HealthPort}" `
-        -v "${TestDataDir}:C:\testdata" `
-        -v "${confDir}:C:\fluent-bit\etc" `
-        -e "FILE_PATH=C:\testdata\fbtest.log" `
-        -e "API_KEY=some-insert-key" `
-        -e "ENDPOINT=$endpoint" `
-        $Image `
-        fluent-bit.exe -c C:\fluent-bit\etc\fluent-bit.conf -e C:\fluent-bit\bin\out_newrelic.dll | Out-Null
+
+    # docker-compose.windows.yml only defines the plugin container, not MockServer - MockServer
+    # isn't a container here (no Windows-container image exists for it), so unlike test.sh's
+    # docker-compose.yml this can't be a symmetric two-service file. It attaches to the NAT
+    # network created above via `external: true`, since ENDPOINT (derived from that network's
+    # gateway IP) must be known before the container starts.
+    $env:NR_FB_IMAGE = $Image
+    $env:CONTAINER_NAME = $ContainerName
+    $env:NETWORK_NAME = $NetworkName
+    $env:HEALTH_PORT = "$HealthPort"
+    $env:TESTDATA_DIR = $TestDataDir
+    $env:CONF_DIR = $confDir
+    $env:ENDPOINT = $endpoint
+
+    docker compose -f $ComposeFile -p $ComposeProject up -d
     if ($LASTEXITCODE -ne 0) {
-        throw "Failed to start container $ContainerName from image $Image"
+        throw "Failed to start container $ContainerName from image $Image via docker-compose"
     }
 
     Write-Step "Sending test log lines"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "3.7.1"
+const VERSION = "3.8.0"


### PR DESCRIPTION
**PR Description :**
1. Upgrading the fluent bit version to 5.0.9
2. Expanding the github workflow to test sending logs from windows instances as well similar to linux.

**Testing Done:** 
1.  Ran `go test ./... ` locally. 
2.  Ran `docker build -f Dockerfile .` locally, which is able to pull latest fluent bit images
3. Ran `bash test.sh` , to test  (full integration: mockserver + real log flow)
4. Automated workflow will test sending logs from both linux and windows instances.


Release Ticket: 
https://new-relic.atlassian.net/browse/NR-600144