### PR TITLE
fix: add least-privilege permissions to workflows (NR-560145)

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -5,10 +5,15 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   cd:
     name: Continuous Delivery pipeline
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
 
     steps:
       - name: Set up Go 1.26.4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,10 +2,17 @@ name: New Relic Fluent Bit Output Plugin - Pull Request
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: CI - Tests and Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Set up Go 1.26.4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,6 @@ jobs:
     name: CI - Tests and Build
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
       checks: write
       pull-requests: write
 

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: New Relic Fluent Bit Output Plugin - Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   repolint:
     name: Run Repolinter

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -10,12 +10,13 @@ on: [push, workflow_dispatch]
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   repolint:
     name: Run Repolinter
     runs-on: ubuntu-24.04
+    permissions:
+      issues: write
     steps:
       - name: Test Default Branch
         id: default-branch


### PR DESCRIPTION
## What PR does ?

- Adds explicit permissions: blocks to 3 GitHub Actions workflows: pr.yaml, merge-to-master.yml, repolinter.yml
- Fixes CodeQL finding NR-560145 (actions/missing-workflow-permissions) — workflows previously ran with GitHub's broad default token permissions instead of only what they need
- pr.yaml → defaults to contents: read; test job adds checks: write + pull-requests: write (needed to publish test results)
- merge-to-master.yml → defaults to contents: read; release job adds contents: write (needed to create GitHub releases/upload assets)
- repolinter.yml → contents: read + issues: write (needed to file lint issues)
- No functional/behavior changes — same builds, tests, and releases run exactly as before, just with tighter token scopes